### PR TITLE
Update Arch Linux package to official one

### DIFF
--- a/content/en/docs/install/_index.md
+++ b/content/en/docs/install/_index.md
@@ -26,10 +26,10 @@ brew install cuelang/tap/cue
 
 ### Installation on Arch Linux
 
-For Arch Linux the community maintains a Arch User Repository package called [cuelang-bin](https://aur.archlinux.org/packages/cuelang-bin/):
+Arch Linux has an official package that you can install by running:
 
 ```
-yay -S cuelang-bin
+pacman -S cuelang-bin
 ```
 
 ## Install CUE from source


### PR DESCRIPTION
CUE has become an official Arch Linux package:

https://twitter.com/Sh1bumi/status/1413892649984036866
https://archlinux.org/packages/community/x86_64/cue/