### PR TITLE
general: remove references to godoc.org

### DIFF
--- a/static/golang/go.html
+++ b/static/golang/go.html
@@ -3,9 +3,9 @@
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8"/>
 <meta name="go-import" content="cuelang.org/go git https://review.gerrithub.io/cue-lang/cue">
 <meta name="go-source" content="cuelang.org/go https://review.gerrithub.io/cue-lang/cue https://review.gerrithub.io/cue-lang/cue/&#43;/master{/dir} https://review.gerrithub.io/cue-lang/cue/&#43;/master{/dir}/{file}">
-<meta http-equiv="refresh" content="0; url=https://godoc.org/cuelang.org/go/">
+<meta http-equiv="refresh" content="0; url=https://pkg.go.dev/cuelang.org/go/">
 </head>
 <body>
-Nothing to see here; <a href="https://godoc.org/cuelang.org/go/">see the package on godoc</a>.
+Nothing to see here; <a href="https://pkg.go.dev/cuelang.org/go/">see the package on godoc</a>.
 </body>
 </html>


### PR DESCRIPTION
Everything has now moved across to pkg.go.dev

Signed-off-by: Paul Jolly <paul@myitcv.io>