### PR TITLE
content: fix brew install command

### DIFF
--- a/content/en/docs/install/_index.md
+++ b/content/en/docs/install/_index.md
@@ -21,7 +21,7 @@ can be downloaded from
 In addition, CUE can be installed with using brew on MacOS and Linux:
 
 ```
-brew install cuelang/tap/cue
+brew install cue-lang/tap/cue
 ```
 
 ### Installation on Arch Linux


### PR DESCRIPTION
The migration "uber" commit in 962a4cc missed updating the brew install
step. Fix that.

Signed-off-by: Paul Jolly <paul@myitcv.io>