### PR TITLE
static: fix go-source meta tag for cuelang.org/go

### DIFF
--- a/static/golang/go.html
+++ b/static/golang/go.html
@@ -2,7 +2,7 @@
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8"/>
 <meta name="go-import" content="cuelang.org/go git https://review.gerrithub.io/cue-lang/cue">
-<meta name="go-source" content="cuelang.org/go https://review.gerrithub.io/cue-lang/cue https://review.gerrithub.io/cue-lang/cue/&#43;/master{/dir} https://review.gerrithub.io/cue-lang/cue/&#43;/master{/dir}/{file}">
+<meta name="go-source" content="cuelang.org/go https://github.com/cue-lang/cue https://github.com/cue-lang/cue/blob/master{/dir} https://github.com/cue-lang/cue/blob/master{/dir}/{file}#L{line}">
 <meta http-equiv="refresh" content="0; url=https://pkg.go.dev/cuelang.org/go/">
 </head>
 <body>


### PR DESCRIPTION
It seems I didn't properly test this pre-migration, and now that the
pkg.go.dev caches have refreshed (still unclear on the frequency of that
cache refresh) it appears the source links from pkg.go.dev pages to
source code are broken.

In this change we also prefer to use GitHub for source code browsing,
even though Gerrit is the source of truth. Reason being, GitHub's source
code browsing, repository navigation etc is far superior, and much
faster. This is somewhat backed up by the fact that the Go project has
shifted away from using Gerrit's gitiles to using the Google-wide code
search interface (speed is probably a factor here too).

Signed-off-by: Paul Jolly <paul@myitcv.io>