### PR TITLE
update Arch Linux cue package

### DIFF
--- a/content/en/docs/install/_index.md
+++ b/content/en/docs/install/_index.md
@@ -29,7 +29,7 @@ brew install cue-lang/tap/cue
 Arch Linux has an official package that you can install by running:
 
 ```
-pacman -S cuelang-bin
+pacman -S cue
 ```
 
 ## Install CUE from source


### PR DESCRIPTION
I think the Arch Linux package is now called cue:

https://archlinux.org/packages/community/x86_64/cue/