### PR TITLE
content: add import statement to protobuf docs

### DIFF
--- a/content/en/docs/integrations/protobuf.md
+++ b/content/en/docs/integrations/protobuf.md
@@ -109,21 +109,24 @@ resides in
 can be converted to CUE using the following Go code
 
 {{< highlight go >}}
-  import (
-  	"cuelang.org/go/cue/format"
-  	"cuelang.org/go/encoding/protobuf"
-  )
+import (
+	"cuelang.org/go/cue/format"
+	"cuelang.org/go/encoding/protobuf"
+	// ...
+)
 
-file, err := protobuf.Extract("basic.proto", nil, &protobuf.Config{
-    Paths: []string{ /* paths to proto includes */ }],
-})
+func main() {
+  file, err := protobuf.Extract("basic.proto", nil, &protobuf.Config{
+      Paths: []string{ /* paths to proto includes */ }],
+  })
 
-if err != nil {
-    log.Fatal(err, "")
+  if err != nil {
+      log.Fatal(err, "")
+  }
+
+  b, _ := format.Node(file)
+  ioutil.WriteFile("out.cue", b, 0644)
 }
-
-b, _ := format.Node(file)
-ioutil.WriteFile("out.cue", b, 0644)
 {{< /highlight  >}}
 
 which will write the following CUE file:

--- a/content/en/docs/integrations/protobuf.md
+++ b/content/en/docs/integrations/protobuf.md
@@ -109,6 +109,11 @@ resides in
 can be converted to CUE using the following Go code
 
 {{< highlight go >}}
+  import (
+  	"cuelang.org/go/cue/format"
+  	"cuelang.org/go/encoding/protobuf"
+  )
+
 file, err := protobuf.Extract("basic.proto", nil, &protobuf.Config{
     Paths: []string{ /* paths to proto includes */ }],
 })


### PR DESCRIPTION
This adds an import statement to the Protobuf section of the Cue
documentation site to help disambiguate the correct package to import. See
related discussion https://github.com/cue-lang/cue/discussions/1362.

Signed-off-by: Dylan Barnard <dylan.barnard@gmail.com>