### PR TITLE
docs/install: fix arch install instructions

### DIFF
--- a/content/en/docs/install/_index.md
+++ b/content/en/docs/install/_index.md
@@ -33,7 +33,7 @@ brew install cue-lang/tap/cue
 Arch Linux has an official package that you can install by running:
 
 ```
-pacman -S cuelang-bin
+pacman -S cue
 ```
 
 ## Install CUE from source


### PR DESCRIPTION
(see commit message)

With thanks to @cbrake who submitted the original fix in #198. That PR
Closes #198.