### PR TITLE
Fix Value.Decode() error handling example

### DIFF
--- a/content/en/docs/integrations/go.md
+++ b/content/en/docs/integrations/go.md
@@ -170,12 +170,12 @@ _ = i.Value().Decode(&x)
 fmt.Println(x)
 
 i, _ = r.Compile("test", `{B: "foo"}`)
-_ = i.Value().Decode(&x)
-fmt.Println(x)
+err := i.Value().Decode(&x)
+fmt.Println(err)
 
 // Output:
 // {2 4}
-// json: cannot unmarshal string into Go struct field ab.B of type int
+// B: cannot use value "foo" (type string) as int
 {{< /highlight >}}
 
 Package


### PR DESCRIPTION
This PR updates the error handling example in "Copy CUE values into Go values" to work as documented. See https://github.com/cue-lang/cue/issues/1592 for additional context.

Note: this does not update the example to use `cue.Context`. As a newcomer to cue I'm not confident enough to make that change.

