### PR TITLE
docs/i18n: fix some Chinese translations in the homepage

### DIFF
--- a/content/zh/_index.html
+++ b/content/zh/_index.html
@@ -9,7 +9,7 @@ linkTitle = "CUE"
 	<h3>
 		<img alt="CUE" width="130" src="/images/cue.svg" />
 		配置 <span style="font-size: 0.7em">(<b>C</b>onfigure)</span>
-		合并 <span style="font-size: 0.7em">(<b>U</b>nify)</span>
+		统一 <span style="font-size: 0.7em">(<b>U</b>nify)</span>
 		执行 <span style="font-size: 0.7em">(<b>E</b>xecute)</span>
 	</h3>
 	<p class="display-2 mt-3 mb-0">
@@ -55,7 +55,7 @@ linkTitle = "CUE"
 
 <!-- todo: replace with zh-cn urls-->
 {{% blocks/feature icon="fa-check-circle" title="数据验证" url="/docs/usecases/validation/" %}}
-校验文字式的数据文件或程序数据，
+校验文本格式的数据文件或程序数据，
 比如传入的 RPC 数据或数据库文档文件。
 {{% /blocks/feature %}}
 
@@ -68,8 +68,8 @@ linkTitle = "CUE"
 <!--
 life-ring map newspaper pause-circle play-circle stop-circle user clipboard comments (two bubbles) file-alt file-code handshake map -->
 <!-- todo: replace with zh-cn urls-->
-{{% blocks/feature icon="fa-handshake" title="结构定义"  url="/docs/usecases/datadef/" %}}
-定义 API 或某个标准通信的结构并且验证向后兼容性。
+{{% blocks/feature icon="fa-handshake" title="定义 Schema"  url="/docs/usecases/datadef/" %}}
+定义 Schema 作为数据标准，与 API 通信或者验证向后兼容性。
 <br>
 <br>
 {{% /blocks/feature %}}
@@ -77,7 +77,7 @@ life-ring map newspaper pause-circle play-circle stop-circle user clipboard comm
 <!-- todo: replace with zh-cn urls-->
 {{% blocks/feature icon="fa-file-code" title="生成代码和结构" url="/docs/usecases/generate/" %}}
 
-保持验证代码在代码库、Protobuf 定义以及 OpenAPI 定义之间保持同步
+使验证代码在代码库、Protobuf 定义以及 OpenAPI 定义之间保持同步
 
 {{% /blocks/feature %}}
 


### PR DESCRIPTION
This PR:

1. Fix the translation of `unify`.
2. Some other small fixes to make the translations more reasonable.

Signed-off-by: Fog Dong <wuwuglu19@gmail.com>

cc @h1z3y3