### PR TITLE
internal/functions/gerritstatusupdater: sanitise env names

### DIFF
--- a/internal/functions/gerritstatusupdater/gerritstatusupdater.go
+++ b/internal/functions/gerritstatusupdater/gerritstatusupdater.go
@@ -379,5 +379,9 @@ func (fn Function) buildGerritHubClient(repo, workflowPath string) (*gerrit.Clie
 // a prefix as required.
 func envJoin(parts ...string) string {
 	parts = append([]string{EnvPrefix}, parts...)
-	return strings.Join(parts, "_")
+	res := strings.Join(parts, "_")
+	res = strings.ReplaceAll(res, ".", "_")
+	res = strings.ReplaceAll(res, "-", "_")
+	res = strings.ReplaceAll(res, "/", "_")
+	return res
 }


### PR DESCRIPTION
Netlify enforce shell-like restrictions on environment variable names.
Therefore we substitute illegal characters, replacing them with _.

Tested via ngrok with a local instance of gerritstatusupdater.

Signed-off-by: Paul Jolly <paul@myitcv.io>