### PR TITLE
gerritstatusupdater: set success status in nil branch of defer

### DIFF
--- a/internal/functions/gerritstatusupdater/gerritstatusupdater.go
+++ b/internal/functions/gerritstatusupdater/gerritstatusupdater.go
@@ -163,7 +163,27 @@ func (fn Function) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		case error:
 			log.Printf("got an error: %v\n", err)
 			http.Error(w, err.Error(), 500)
-		case nil:
+		case nil: // normal return
+			// We currently see a whole load of errors in the GitHub webhook logs:
+			//
+			//    error decoding lambda response: invalid status code returned from lambda: 0
+			//
+			// However, these do not correspond to any errors in the Netlify function
+			// logs.
+			//
+			// We use github.com/apex/gateway in order to reuse regular
+			// net/http.HandleFunc handlers as part of the AWS Lambda setup. gateway is
+			// therefore an adapter between net/http and AWS Lambda setup. However, it
+			// appears that gateway to does not have any handling for a situation where
+			// no HTTP status code is written. Currently, it appears that not writing
+			// an HTTP status code as part of the net/http.HandleFunc handler results
+			// in a 0 status code being return to the AWS Lambda handler. Contrast this
+			// with the behaviour of regular net/http.ListenAndServe, which writes a
+			// 200 in case no status code has been written.
+			//
+			// Fix this by simply writing a 200 status OK in case we return
+			// successfully.
+			w.WriteHeader(http.StatusOK)
 		default:
 			panic(err)
 		}
@@ -270,8 +290,6 @@ func (fn Function) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 	case *github.PingEvent:
-		// Handle this to be a good citizen from GitHub's perspective
-		w.Write([]byte("pong"))
 		return
 	default:
 		panic(fmt.Errorf("unhandled event type %T", event))
@@ -318,27 +336,6 @@ func (fn Function) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		b, _ := json.MarshalIndent(ri, "", "  ")
 		log.Printf("gerrit.SetReview %s/%s with\n%s\n", changeID, revisionID, b)
 	}
-
-	// We currently see a whole load of errors in the GitHub webhook logs:
-
-	//    error decoding lambda response: invalid status code returned from lambda: 0
-
-	// However, these do not correspond to any errors in the Netlify function
-	// logs.
-
-	// We use github.com/apex/gateway in order to reuse regular
-	// net/http.HandleFunc handlers as part of the AWS Lambda setup. gateway is
-	// therefore an adapter between net/http and AWS Lambda setup. However, it
-	// appears that gateway to does not have any handling for a situation where
-	// no HTTP status code is written. Currently, it appears that not writing
-	// an HTTP status code as part of the net/http.HandleFunc handler results
-	// in a 0 status code being return to the AWS Lambda handler. Contrast this
-	// with the behaviour of regular net/http.ListenAndServe, which writes a
-	// 200 in case no status code has been written.
-
-	// Fix this by simply writing a 200 status OK in case we return
-	// successfully.
-	w.WriteHeader(http.StatusOK)
 }
 
 // buildGitHubClient returns a GitHub client, deriving authentication for the


### PR DESCRIPTION
This correctly captures the cases where we successfully perform an early
return from our handler.

As part of this change, don't pother write "pong" in response to a ping.
A 200 response code is sufficient.

Signed-off-by: Paul Jolly <paul@myitcv.io>