### PR TITLE
netlify.toml: add redirect rule for Gerrit CLs

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -13,6 +13,12 @@ HUGO_VERSION = "0.89.4"
 command = "bash build.bash -b $DEPLOY_URL"
 
 [[redirects]]
+  from = "/cl/*"
+  to = "https://review.gerrithub.io/c/cue-lang/cue/+/:splat"
+  status = 302
+  force = true
+
+[[redirects]]
   from = "https://cuelang.org/issue/*"
   to = "https://github.com/cue-lang/cue/issues/:splat"
   status = 302


### PR DESCRIPTION
Currently we redirect cuelang.org/issue/123 to our issue tracker.
This change will add a similar rule for GerritHub CLs. For example,
https://cuelang.org/cl/538063 will now redirect to
https://review.gerrithub.io/c/cue-lang/cue/+/538063 for future
portability and convenience.

Fixes #264

Signed-off-by: Cedric Charly <cedric.charly@gmail.com>