### PR TITLE
netlify.toml: use partial paths for redirects

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -19,25 +19,25 @@ command = "bash build.bash -b $DEPLOY_URL"
   force = true
 
 [[redirects]]
-  from = "https://cuelang.org/issue/*"
+  from = "/issue/*"
   to = "https://github.com/cue-lang/cue/issues/:splat"
   status = 302
   force = true
 
 [[redirects]]
-  from = "https://cuelang.org/issues/*"
+  from = "/issues/*"
   to = "https://github.com/cue-lang/cue/issues/:splat"
   status = 302
   force = true
 
 [[redirects]]
-  from = "https://cuelang.org/discussion/*"
+  from = "/discussion/*"
   to = "https://github.com/cue-lang/cue/discussions/:splat"
   status = 302
   force = true
 
 [[redirects]]
-  from = "https://cuelang.org/releases/*"
+  from = "/releases/*"
   to = "https://github.com/cue-lang/cue/releases/:splat"
   status = 302
   force = true


### PR DESCRIPTION
Removing the domain part of the URL in the `from` fields ensures that
netlify will trigger the redirect on any domain. Going forward we should
be able to check redirects on preview deploys before merging.

Signed-off-by: Cedric Charly <cedric.charly@gmail.com>
