### PR TITLE
internal/ci/netlify: capture feedback missed in last PR

### DIFF
--- a/internal/ci/netlify/netlify.cue
+++ b/internal/ci/netlify/netlify.cue
@@ -112,8 +112,10 @@ config: #config & {
 		  from = {{printf "%q" .from}}
 		  to = {{printf "%q" .to}}
 		  status = {{printf "%d" .status}}
-		  force = {{printf "%v" .force}}
+		  force = {{printf "%t" .force}}
 		{{end}}
 		"""
+
+	// TODO: move to encoding/toml when it exists. See cuelang.org/issue/68.
 	template.Execute(tmpl, #input)
 }


### PR DESCRIPTION
Whilst working on the feedback from @mvdan in #285, I briefly got distracted. I had made two of the changes he requested locally, then marked them as resolved in the PR, but then got pulled away before I force-pushed the PR with the fixes.

Actually make those two changes.

Signed-off-by: Paul Jolly <paul@myitcv.io>