### PR TITLE
Website/Hugo: Search template

### DIFF
--- a/assets/scss/components/search.scss
+++ b/assets/scss/components/search.scss
@@ -1,0 +1,7 @@
+/* Note: For now overrule some google search styles, in future will be custom search bem */
+.search {
+    .gsc-above-wrapper-area-container {
+        border-radius: 0;
+        overflow: visible;
+    }
+}

--- a/assets/scss/components/searchbar.scss
+++ b/assets/scss/components/searchbar.scss
@@ -1,0 +1,28 @@
+@import '../config/sizes';
+@import '../mixins/sr-only';
+
+.searchbar {
+    &__label {
+        @include sr-only;
+    }
+
+    &__bar {
+        position: relative;
+    }
+
+    &__input {
+        &[type='text'] {
+            border-radius: 50px;
+            border-width: 2px;
+            height: $h-button + 16px;
+            padding: 0 ($h-button + 12px) 0 2rem;
+        }
+    }
+
+    &__button {
+        position: absolute;
+        right: 8px;
+        top: 50%;
+        transform: translateY(-50%);
+    }
+}

--- a/assets/scss/components/section.scss
+++ b/assets/scss/components/section.scss
@@ -121,6 +121,14 @@
                 text-align: center;
             }
         }
+
+
+        &--search {
+            #{ $self }__header {
+                padding-bottom: 2rem;
+            }
+        }
+
     }
 
     @include screen($screen-normal) {

--- a/assets/scss/main.scss
+++ b/assets/scss/main.scss
@@ -35,6 +35,8 @@
 @import 'components/playground';
 // @import 'components/popover';
 @import 'components/prevnext';
+@import 'components/search';
+@import 'components/searchbar';
 @import 'components/separator';
 @import 'components/spinner';
 @import 'components/table';

--- a/layouts/_default/search.html
+++ b/layouts/_default/search.html
@@ -1,16 +1,41 @@
 {{ define "main" }}
     <section class="section section--search">
         <header class="section__header">
-            <h1 class="section__title">{{ .Title }}</h1>
-            <div class="todo"><span class="todo__note">TODO</span><span class="todo__desc">Form</span></div>
+            <div class="section__content">
+                <h1 class="section__title">{{ .Title }}</h1>
+            </div>
         </header>
-        <div class="section__container">
-            <gcse:searchresults-only>{{ partial "spinner.html" }}</gcse:searchresults-only>
+        <div class="section__body">
+            <div class="section__content">
+                <form action="{{ .RelPermalink }}" method="get">
+                    <div class="searchbar">
+                        <label for="searchbar" class="searchbar__label">{{ T "ui_search" }}</label>
+                        <div class="searchbar__bar">
+                            <input name="q" type="text" id="searchbar" class="searchbar__input">
+                            <button type="submit" class="button button--icon searchbar__button">
+                                {{- partial "icon.html" (dict "icon" "search" "class" "button__icon") -}}
+                                <span>{{ T "ui_search" }}</span>
+                            </button>
+                        </div>
+                    </div>
+                </form>
+
+                <div class="search">
+                    <gcse:searchresults-only>{{ partial "spinner.html" }}</gcse:searchresults-only>
+                </div>
+            </div>
         </div>
     </section>
     <script>
+        const params = new URLSearchParams(window.location.search);
+        const query = params.get('q');
+        const input = document.getElementById('searchbar');
+        if (input && query) {
+            input.value = query;
+        }
+
         (function() {
-            var cx = '{{ . }}';
+            var cx = '004591905419617723008:8rmik2a7xb3';
             var gcse = document.createElement('script');
             gcse.type = 'text/javascript';
             gcse.async = true;


### PR DESCRIPTION
- Add searchbar to search template
- Add google search cx ID to template
- Overrule some google & base styles within search.scss
- Add some custom lines to google script tag to get value of search parameter and set value in input to see currently searched term

Signed-off-by: Jorinde Reijnierse <jorinde.reijnierse@usmedia.nl>

Test url: https://deploy-preview-299--cue.netlify.app/search/
For the broken icons on the preview url's we've created a new issue in Linear: CUE-128