### PR TITLE
Netlify: Fix baseUrl for preview-deploy

### DIFF
--- a/internal/ci/netlify/netlify.cue
+++ b/internal/ci/netlify/netlify.cue
@@ -60,7 +60,7 @@ config: #config & {
 		}
 	}
 
-	context: "deploy-preview": command: "bash build.bash -b $DEPLOY_URL"
+	context: "deploy-preview": command: "bash build.bash -b $DEPLOY_PRIME_URL"
 
 	redirects: [...{force: true, status: 302}]
 	redirects: [{

--- a/netlify.toml
+++ b/netlify.toml
@@ -12,7 +12,7 @@ HUGO_VERSION = "0.108.0"
 NODE_VERSION = "18.12.1"
 
 [context.deploy-preview]
-command = "bash build.bash -b $DEPLOY_URL"
+command = "bash build.bash -b $DEPLOY_PRIME_URL"
 
 [[redirects]]
   from = "/cl/*"


### PR DESCRIPTION
Issue: Base url was not set correctly on preview builds which causes e.g. svg sprites to be blocked because of url mismatches Based on answers here: https://discourse.gohugo.io/t/correct-baseurl-on-netlify-previews/10429 we need to use $DEPLOY_PRIME_URL instead of $DEPLOY_URL

Signed-off-by: Jorinde Reijnierse <jorinde.reijnierse@usmedia.nl>