### PR TITLE
Website/Hugo: Styling of nested list

### DIFF
--- a/assets/scss/base/base.scss
+++ b/assets/scss/base/base.scss
@@ -171,6 +171,14 @@ ol {
         ol {
             margin: .5rem 0 0;
         }
+
+        ul {
+            li {
+                &::before {
+                    content: '\0025E6';
+                }
+            }
+        }
     }
 }
 


### PR DESCRIPTION
Issue: Nested lists where not styled correctly so it was hard to differentiate the list-levels. 
Fixed by using an open-bullet character for the nested list instead of a filled bullet.

Test url: https://deploy-preview-303--cue.netlify.app/examples/basic/block/ 