### PR TITLE
Fix syntax highlight and add option for title to (fenced) code blocks

### DIFF
--- a/hugo/assets/scss/base/base.scss
+++ b/hugo/assets/scss/base/base.scss
@@ -347,6 +347,7 @@ pre {
     border: 1px solid var(--pre-border-color);
     border-radius: 5px;
     color: var(--pre-color);
+    height: 100%;
     margin-bottom: 1rem;
     max-width: 100%;
     overflow: auto;

--- a/hugo/assets/scss/components/columns.scss
+++ b/hugo/assets/scss/components/columns.scss
@@ -14,7 +14,9 @@
         &__col {
             @include marginless-child;
 
+            display: flex;
             flex: 0 1 50%;
+            flex-direction: column;
             max-width: 50%;
         }
     }

--- a/hugo/assets/scss/components/highlight.scss
+++ b/hugo/assets/scss/components/highlight.scss
@@ -1,0 +1,32 @@
+@import '../config/typography';
+@import '../mixins/screen';
+
+.highlight {
+    $self: &;
+
+    height: 100%;
+    position: relative;
+
+    &__title {
+        background-color: var(--pre-background-color);
+        border-radius: 5px 5px 0 0;
+        font-weight: $weight-medium;
+        padding: 1rem 1.25rem 0 1.25rem;
+
+        + #{ $self } {
+            pre {
+                border-radius: 0 0 5px 5px;
+                padding-top: 0;
+            }
+        }
+    }
+
+    pre {
+        background-color: var(--pre-background-color) !important; // needs !important otherwise Hugo overwrites the styling
+        margin: 0;
+    }
+
+    @include screen($screen-simple) {
+        margin-bottom: 1rem;
+    }
+}

--- a/hugo/assets/scss/main.scss
+++ b/hugo/assets/scss/main.scss
@@ -22,6 +22,7 @@
 @import 'components/drawer';
 @import 'components/footer';
 @import 'components/header';
+@import 'components/highlight';
 @import 'components/index';
 @import 'components/lastmod';
 @import 'components/link';

--- a/hugo/config/_default/markup.toml
+++ b/hugo/config/_default/markup.toml
@@ -22,8 +22,6 @@ defaultMarkdownHandler = "goldmark"
 
 [highlight]
     style = "trac"
-    lineNumbersInTable = true
-    noClasses = false
 
 [tableOfContents]
     endLevel = 2

--- a/hugo/content/en/examples/basic/block/index.md
+++ b/hugo/content/en/examples/basic/block/index.md
@@ -210,26 +210,125 @@ To create code blocks, indent every line of the block by at least four spaces or
 Optionally you can also use Fenced Code Blocks, you’ll use three backticks (```) or three tildes (~~~) on the lines before and after the code block.
 This way you don’t have to indent any lines!
 
-
 {{< columns >}}
+````
 ```
-    ```
-    {
-        "firstName": "John",
-        "lastName": "Smith",
-        "age": 25
-    }
-    ```
+{
+    "firstName": "John",
+    "lastName": "Smith",
+    "age": 25
+}
 ```
+````
 {{< columns-separator >}}
 ```
 {
-  "firstName": "John",
-  "lastName": "Smith",
-  "age": 25
+    "firstName": "John",
+    "lastName": "Smith",
+    "age": 25
 }
 ```
 {{< /columns >}}
+
+### Syntax Highlighting
+
+You can also use syntax highlighting with Fenced Code Blocks. For this you only have to add the language after the backticks.
+
+{{< columns >}}
+````
+```json
+{
+    "firstName": "John",
+    "lastName": "Smith",
+    "age": 25
+}
+```
+````
+{{< columns-separator >}}
+```json
+{
+    "firstName": "John",
+    "lastName": "Smith",
+    "age": 25
+}
+```
+{{< /columns >}}
+
+[Here](https://gohugo.io/content-management/syntax-highlighting/#list-of-chroma-highlighting-languages) is a list of all the languages that can get syntax styling.
+
+You can also add a title.
+
+{{< columns >}}
+````
+```json {title="JSON"}
+{
+    "firstName": "John",
+    "lastName": "Smith",
+    "age": 25
+}
+```
+````
+{{< columns-separator >}}
+```json {title="JSON"}
+{
+    "firstName": "John",
+    "lastName": "Smith",
+    "age": 25
+}
+```
+{{< /columns >}}
+
+You can even mark/highlight part of the code by adding `hl_lines` with the according lines you want to highlight:
+
+{{< columns >}}
+````
+```json {title="JSON", hl_lines=["2-3", 6]}
+{
+    "firstName": "John",
+    "lastName": "Smith",
+    "age": 25,
+    "residence": "Amsterdam",
+    "occupation": "Developer
+}
+```
+````
+{{< columns-separator >}}
+```json {title="JSON", hl_lines=["2-3", 6]}
+{
+    "firstName": "John",
+    "lastName": "Smith",
+    "age": 25,
+    "residence": "Amsterdam",
+    "occupation": "Developer"
+}
+```
+{{< /columns >}}
+
+Other options that can be added after defining a language can be found [here](https://gohugo.io/content-management/syntax-highlighting/#highlight-shortcode).
+
+The above examples are created by using the `columns` and `columns-separator` [shortcode]({{< ref "examples/shortcodes/columns/index.md" >}}). Of course it is also possible to have a code example that is page-wide.
+
+````
+```bash
+brew install cue-lang/tap/cue
+```
+````
+
+```bash
+brew install cue-lang/tap/cue
+```
+
+With title
+
+````
+```vshell {title="V shell"}
+brew install cue-lang/tap/cue
+```
+````
+
+```vshell {title="V shell"}
+brew install cue-lang/tap/cue
+```
 
 ---
 

--- a/hugo/layouts/_default/_markup/render-codeblock.html
+++ b/hugo/layouts/_default/_markup/render-codeblock.html
@@ -1,0 +1,7 @@
+{{- with (index .Attributes "title") -}}
+    <div class="highlight__title">
+        {{- . -}}
+    </div>
+{{- end -}}
+
+{{- highlight .Inner .Type .Options -}}


### PR DESCRIPTION
This includes:
- Remove default highlight config
- Remove highlight config that breaks syntax highlighting (noClasses = false)
- Add option to add title to fenced code block
- Add examples of extra options to example page (/examples/basic/block#code-blocks)
- Adjust pre styling for code blocks

For https://linear.app/usmedia/issue/CUE-14