### PR TITLE
Add upcoming shortcodes to example page (/examples/)

### DIFF
--- a/hugo/content/en/examples/_index.html
+++ b/hugo/content/en/examples/_index.html
@@ -54,8 +54,18 @@ description: "View examples on how to use certain possible elements of the theme
                             </a>
                         </li>
                         <li class="nav__item">
+                            <a class="nav__link" href="#" disabled>
+                                <span class="nav__text">Carousel</span>
+                            </a>
+                        </li>
+                        <li class="nav__item">
                             <a class="nav__link" href="/examples/shortcodes/columns/">
                                 <span class="nav__text">Columns</span>
+                            </a>
+                        </li>
+                        <li class="nav__item">
+                            <a class="nav__link" href="#" disabled>
+                                <span class="nav__text">CTA</span>
                             </a>
                         </li>
                         <li class="nav__item">
@@ -63,6 +73,13 @@ description: "View examples on how to use certain possible elements of the theme
                                 <span class="nav__text">Diagrams</span>
                             </a>
                         </li>
+                    </ul>
+                </div>
+
+                <div class="index__nav nav nav--index">
+                    <p class="nav__title">Shortcodes</p>
+
+                    <ul class="nav__list">
                         <li class="nav__item">
                             <a class="nav__link" href="/examples/shortcodes/info/">
                                 <span class="nav__text">Info Block</span>
@@ -74,8 +91,18 @@ description: "View examples on how to use certain possible elements of the theme
                             </a>
                         </li>
                         <li class="nav__item">
+                            <a class="nav__link" href="#" disabled>
+                                <span class="nav__text">Quote</span>
+                            </a>
+                        </li>
+                        <li class="nav__item">
                             <a class="nav__link" href="/examples/shortcodes/ref-relref/">
                                 <span class="nav__text">Ref & relref</span>
+                            </a>
+                        </li>
+                        <li class="nav__item">
+                            <a class="nav__link" href="/examples/shortcodes/sidenote/">
+                                <span class="nav__text">Sidenote</span>
                             </a>
                         </li>
                     </ul>
@@ -85,11 +112,6 @@ description: "View examples on how to use certain possible elements of the theme
                     <p class="nav__title">Shortcodes</p>
 
                     <ul class="nav__list">
-                        <li class="nav__item">
-                            <a class="nav__link" href="/examples/shortcodes/sidenote/">
-                                <span class="nav__text">Sidenote</span>
-                            </a>
-                        </li>
                         <li class="nav__item">
                             <a class="nav__link" href="/examples/shortcodes/spinner/">
                                 <span class="nav__text">Spinner</span>

--- a/hugo/content/en/examples/shortcodes/carousel/index.md
+++ b/hugo/content/en/examples/shortcodes/carousel/index.md
@@ -1,0 +1,6 @@
+---
+title: Carousel
+weight: 22
+---
+
+{{< todo >}}

--- a/hugo/content/en/examples/shortcodes/columns/index.md
+++ b/hugo/content/en/examples/shortcodes/columns/index.md
@@ -1,6 +1,6 @@
 ---
 title: Columns
-weight: 22
+weight: 23
 ---
 
 If you have content you want to show side-by-side, you can use the `{{</* columns */>}}` shortcode.

--- a/hugo/content/en/examples/shortcodes/cta/index.md
+++ b/hugo/content/en/examples/shortcodes/cta/index.md
@@ -1,0 +1,6 @@
+---
+title: CTA
+weight: 24
+---
+
+{{< todo >}}

--- a/hugo/content/en/examples/shortcodes/diagrams/index.md
+++ b/hugo/content/en/examples/shortcodes/diagrams/index.md
@@ -1,6 +1,6 @@
 ---
 title: Diagrams
-weight: 23
+weight: 25
 ---
 
 There is built in support for multiple types of diagrams.

--- a/hugo/content/en/examples/shortcodes/info/index.md
+++ b/hugo/content/en/examples/shortcodes/info/index.md
@@ -1,6 +1,6 @@
 ---
 title: Info blocks
-weight: 24
+weight: 26
 ---
 
 There are a couple of shortcodes you can use inorder to highlight a piece of content.

--- a/hugo/content/en/examples/shortcodes/param/index.md
+++ b/hugo/content/en/examples/shortcodes/param/index.md
@@ -1,6 +1,6 @@
 ---
 title: Param
-weight: 25
+weight: 27
 description: "This page shows an example of the param shortcode"
 ---
 

--- a/hugo/content/en/examples/shortcodes/quote/index.md
+++ b/hugo/content/en/examples/shortcodes/quote/index.md
@@ -1,0 +1,6 @@
+---
+title: Quote
+weight: 28
+---
+
+{{< todo >}}

--- a/hugo/content/en/examples/shortcodes/ref-relref/index.md
+++ b/hugo/content/en/examples/shortcodes/ref-relref/index.md
@@ -1,6 +1,6 @@
 ---
 title: Ref & relref
-weight: 26
+weight: 29
 ---
 
 These shortcodes will look up the pages by their relative path (e.g., blog/post.md) or their logical name (post.md) and return the permalink (ref) or relative permalink (relref) for the found page.

--- a/hugo/content/en/examples/shortcodes/sidenote/index.md
+++ b/hugo/content/en/examples/shortcodes/sidenote/index.md
@@ -1,6 +1,6 @@
 ---
 title: Sidenote
-weight: 27
+weight: 30
 ---
 
 {{< sidenote text="Only in CUE v04.3" >}}

--- a/hugo/content/en/examples/shortcodes/spinner/index.md
+++ b/hugo/content/en/examples/shortcodes/spinner/index.md
@@ -1,6 +1,6 @@
 ---
 title: Spinner
-weight: 28
+weight: 31
 ---
 
 The spinner shortcode is used to show a simple spinner. Not really needed in content - but it can be used in certain pieces of content which are replaced with Javascript.

--- a/hugo/content/en/examples/shortcodes/table/index.md
+++ b/hugo/content/en/examples/shortcodes/table/index.md
@@ -1,6 +1,6 @@
 ---
 title: Table
-weight: 29
+weight: 32
 ---
 
 ## Basic table

--- a/hugo/content/en/examples/shortcodes/tabs/index.md
+++ b/hugo/content/en/examples/shortcodes/tabs/index.md
@@ -1,0 +1,6 @@
+---
+title: Tabs
+weight: 33
+---
+
+{{< todo >}}

--- a/hugo/content/en/examples/shortcodes/todo/index.md
+++ b/hugo/content/en/examples/shortcodes/todo/index.md
@@ -1,6 +1,6 @@
 ---
 title: Todo
-weight: 31
+weight: 34
 ---
 
 The todo shortcode is a simple shortcode used to show a section / block which is still under construction.
@@ -20,4 +20,3 @@ You can replace the default message with one of your own.
 ```
 
 {{< todo "A custom message" >}}
-

--- a/hugo/content/en/examples/shortcodes/youtube/index.md
+++ b/hugo/content/en/examples/shortcodes/youtube/index.md
@@ -1,6 +1,6 @@
 ---
 title: YouTube
-weight: 32
+weight: 35
 ---
 
 When using the youtube shortcode, you will need the Video ID associated YouTube video.


### PR DESCRIPTION
- Added disabled links for future shortcodes 
    - Carousel 
    - CTA 
    - Quote
- Created empty pages for the upcoming shortcodes 
    - Carousel 
    - CTA 
    - Quote 
    - Tabs
- Fixed the order/weights of the shortcodes with the upcoming shortcodes in mind

For [https://linear.app/usmedia/issue/CUE-159](https://linear.app/usmedia/issue/CUE-159)