### PR TITLE
Hugo: Moved 'Download and Install CUE ' in code

### DIFF
--- a/hugo/content/en/docs/_index.html
+++ b/hugo/content/en/docs/_index.html
@@ -47,8 +47,6 @@ cascade:
                                 <span class="nav__text">Tour</span>
                             </a>
                         </li>
-                    </ul>
-                    <ul class="nav__list">
                         <li class="nav__item">
                             <a class="nav__link" href="/download">
                                 <span class="nav__text">Download and Install CUE </span>


### PR DESCRIPTION
Moved 'Download and Install CUE' to the <ul> above, so the extra yellow stripe won't show anymore