### PR TITLE
Hugo: Disable links upcoming pages docs

### DIFF
--- a/hugo/assets/scss/components/tree.scss
+++ b/hugo/assets/scss/components/tree.scss
@@ -38,6 +38,16 @@
     &__link {
         display: block;
         text-decoration: none;
+
+        &[disabled] {
+            color: $c-grey--dark;
+            cursor: default;
+            pointer-events: none;
+
+            #{ $self }__text {
+                background-size: 0 0;
+            }
+        }
     }
 
     &__text {

--- a/hugo/content/en/docs/howto/constrain-list-ints-no-duplicates/index.md
+++ b/hugo/content/en/docs/howto/constrain-list-ints-no-duplicates/index.md
@@ -1,5 +1,6 @@
 ---
 title: How to constrain a list of integers to have no duplicates
-weight: 
+weight:
 draft: false
+disabled: true
 ---

--- a/hugo/content/en/docs/howto/constrain-list-strings-no-duplicates/index.md
+++ b/hugo/content/en/docs/howto/constrain-list-strings-no-duplicates/index.md
@@ -1,5 +1,6 @@
 ---
 title: How to constrain a list of strings with no duplicates
-weight: 
+weight:
 draft: false
+disabled: true
 ---

--- a/hugo/content/en/docs/howto/constrain-list-structs-no-duplicates/index.md
+++ b/hugo/content/en/docs/howto/constrain-list-structs-no-duplicates/index.md
@@ -2,4 +2,5 @@
 title: How to constrain a list of structs with no duplicates
 weight:
 draft: false
+disabled: true
 ---

--- a/hugo/content/en/docs/howto/constrain-max-items-list/index.md
+++ b/hugo/content/en/docs/howto/constrain-max-items-list/index.md
@@ -2,4 +2,5 @@
 title: How to constrain the maximum items in a list
 weight:
 draft: false
+disabled: true
 ---

--- a/hugo/content/en/docs/howto/constrain-min-items-list/index.md
+++ b/hugo/content/en/docs/howto/constrain-min-items-list/index.md
@@ -2,4 +2,5 @@
 title: How to constrain the minimum items in a list
 weight:
 draft: false
+disabled: true
 ---

--- a/hugo/content/en/docs/howto/encode-data-json-string-within-cue/index.md
+++ b/hugo/content/en/docs/howto/encode-data-json-string-within-cue/index.md
@@ -2,4 +2,5 @@
 title: How to encode data as a JSON string within a larger CUE value
 weight:
 draft: false
+disabled: true
 ---

--- a/hugo/content/en/docs/howto/use-cue-with-github-actions/index.md
+++ b/hugo/content/en/docs/howto/use-cue-with-github-actions/index.md
@@ -2,4 +2,5 @@
 title: How to use CUE with GitHub Actions
 weight:
 draft: false
+disabled: true
 ---

--- a/hugo/content/en/docs/language-guide/file-organization/index.md
+++ b/hugo/content/en/docs/language-guide/file-organization/index.md
@@ -2,4 +2,5 @@
 title: File Organization
 weight: 80
 draft: false
+disabled: true
 ---

--- a/hugo/content/en/docs/language-guide/getting-started/index.md
+++ b/hugo/content/en/docs/language-guide/getting-started/index.md
@@ -2,4 +2,5 @@
 title: Getting Started
 weight: 20
 draft: false
+disabled: true
 ---

--- a/hugo/content/en/docs/language-guide/interoperability/index.md
+++ b/hugo/content/en/docs/language-guide/interoperability/index.md
@@ -2,4 +2,5 @@
 title: Interoperability
 weight: 90
 draft: false
+disabled: true
 ---

--- a/hugo/content/en/docs/language-guide/policy/index.md
+++ b/hugo/content/en/docs/language-guide/policy/index.md
@@ -2,4 +2,5 @@
 title: Policy
 weight: 70
 draft: false
+disabled: true
 ---

--- a/hugo/content/en/docs/language-guide/queries/index.md
+++ b/hugo/content/en/docs/language-guide/queries/index.md
@@ -2,4 +2,5 @@
 title: Queries
 weight: 60
 draft: false
+disabled: true
 ---

--- a/hugo/content/en/docs/language-guide/schemas/index.md
+++ b/hugo/content/en/docs/language-guide/schemas/index.md
@@ -2,4 +2,5 @@
 title: Schemas
 weight: 50
 draft: false
+disabled: true
 ---

--- a/hugo/content/en/docs/language-guide/templating/index.md
+++ b/hugo/content/en/docs/language-guide/templating/index.md
@@ -2,4 +2,5 @@
 title: Templating
 weight: 40
 draft: false
+disabled: true
 ---

--- a/hugo/i18n/en.toml
+++ b/hugo/i18n/en.toml
@@ -63,6 +63,8 @@ other = "Last modified"
 # Docs
 [docs_show_nav]
 other = "Show navigation"
+[docs_coming_soon]
+other = "this page will be coming soon"
 
 # Redirect page
 [redirect_title]

--- a/hugo/layouts/docs/single.html
+++ b/hugo/layouts/docs/single.html
@@ -10,7 +10,14 @@
                         <h1 class="article__title">{{ .Title }}</h1>
                     </header>
                     <div class="article__content">
-                        {{ .Content }}
+                        {{ if .Params.disabled }}
+                            <div class="todo">
+                                <span class="todo__note">TODO</span>
+                                <span class="todo__desc">{{ T "docs_coming_soon" }}</span>
+                            </div>
+                        {{ else }}
+                            {{ .Content }}
+                        {{ end }}
                     </div>
                     <footer class="article__footer">
                         {{ partial "last-modified.html" . }}

--- a/hugo/layouts/partials/paging/section-index.html
+++ b/hugo/layouts/partials/paging/section-index.html
@@ -10,7 +10,7 @@
         <ul class="nav__list">
             {{ range $pages }}
                 <li class="nav__item">
-                    <a class="nav__link" href="{{ .RelPermalink }}">
+                    <a class="nav__link" href="{{ .RelPermalink }}"{{ if .Params.disabled }} disabled{{ end }}>
                         <span class="nav__text">{{ .LinkTitle }}</span>
                     </a>
                 </li>

--- a/hugo/layouts/partials/paging/tree.html
+++ b/hugo/layouts/partials/paging/tree.html
@@ -47,7 +47,7 @@
     {{ $withChildren := and (gt (len $pages) 0) (ne $depth $maxDepth) -}}
 
     <li class="tree__item{{ if $withChildren }} has-children{{ end }}{{ if $isActivePath }} is-active-path{{ end }}{{ if $isActive }} is-active{{ end }}">
-        <a class="tree__link" href="{{ $s.RelPermalink }}" title="{{ $s.LinkTitle }}">
+        <a class="tree__link" href="{{ $s.RelPermalink }}" title="{{ $s.LinkTitle }}"{{ if $s.Params.disabled }} disabled{{ end }}>
             <span class="tree__text">{{ $s.LinkTitle }}</span>
         </a>
 


### PR DESCRIPTION
- Added coming_soon to frontmatter empty pages
- Set page link in nav tree to disabled when coming_soon = true
- Set page link in overview to disabled when coming_soon = true
- Set page link in prev/next to disabled when coming_soon = true
- Added disabled link styling to nav tree links

For https://linear.app/usmedia/issue/CUE-165