### PR TITLE
Hugo: Shortcode Tabs

### DIFF
--- a/hugo/assets/scss/components/tabs-nav.scss
+++ b/hugo/assets/scss/components/tabs-nav.scss
@@ -1,0 +1,144 @@
+@import '../config/colors';
+@import '../config/sizes';
+@import '../mixins/stretch';
+@import '../mixins/typography';
+
+.tabs-nav {
+    $self: &;
+
+    border-bottom: 1px solid var(--tabs-nav-border,  transparentize($c-blue--darker, .9));
+    display: flex;
+    overflow: hidden;
+
+    &__tabs {
+        display: flex;
+        overflow-x: auto;
+        padding: 0 $p-gutter;
+        scroll-behavior: smooth;
+        scrollbar-width: none;
+    }
+
+    &__item {
+        flex: 0 0 auto;
+        padding-right: 1.75rem;
+
+        &:last-child {
+            padding-right: 0;
+        }
+    }
+
+    &__tab {
+        color: var(--tab-color, $c-blue--darker);
+        display: block;
+        height: 52px;
+        line-height: 52px;
+        position: relative;
+        text-align: center;
+        transition: color .2s, background-color .2s;
+
+        &::after {
+            bottom: 0;
+            content: '';
+            display: block;
+            height: 4px;
+            left: 0;
+            position: absolute;
+            transition: background-color .2s;
+            width: 100%;
+        }
+
+        &:focus,
+        &:hover {
+            color: var(--tab-color-hover, $c-blue--light);
+
+            &::after {
+                background-color: var(--tab-border-color, $c-yellow);
+            }
+        }
+
+        &.is-active {
+            color: var(--tab-color-active, $c-blue--darker);
+            font-weight: $weight-bold;
+
+            &::after {
+                background-color: var(--tab-border-color-active, $c-yellow);
+            }
+        }
+    }
+
+    &__pagination {
+        align-items: center;
+        box-shadow: 0 2px 4px -1px transparentize($c-black, .8), 0 4px 5px 0 transparentize($c-black, .86), 0 1px 10px 0 transparentize($c-black, .88);
+        color: $c-black;
+        display: flex;
+        flex: 0 0 36px;
+        justify-content: center;
+        overflow: hidden;
+        position: relative;
+        width: 36px;
+
+        &::before {
+            @include stretch;
+
+            background-color: transparentize($c-grey--lighter, .5);
+            border-radius: 20px;
+            content: '';
+            display: block;
+            height: 140%;
+            pointer-events: none;
+            transform: scale(0) translate(-20%, -20%);
+            transform-origin: left bottom;
+            transition: transform .2s;
+            width: 140%;
+        }
+
+        &:focus,
+        &:hover {
+            color: $c-grey--dark;
+
+            &::before {
+                transform: scale(1) translate(-20%, -20%);
+            }
+        }
+
+        &:disabled {
+            box-shadow: none;
+            color: $c-grey--light;
+            pointer-events: none;
+        }
+
+        &.is-hidden {
+            display: none;
+        }
+    }
+
+    &__icon {
+        display: block;
+        height: 24px;
+        position: relative;
+        width: 24px;
+    }
+
+    &--prev {
+        margin-left: #{-$p-gutter};
+    }
+
+    &--next {
+        margin-right: #{-$p-gutter};
+    }
+
+    @include screen($screen-simple) {
+        &__pagination {
+            display: none;
+        }
+
+        &__tabs {
+            padding-left: var(--tabs-gutter, 30px);
+        }
+
+        &__item {
+            padding-left: 0;
+            padding-right: $p-gutter--large;
+        }
+    }
+}

--- a/hugo/assets/scss/components/tabs.scss
+++ b/hugo/assets/scss/components/tabs.scss
@@ -1,0 +1,55 @@
+@import '../config/colors';
+@import '../config/sizes';
+@import '../mixins/screen';
+
+.tabs {
+    --tabs-gutter: #{ $p-gutter };
+
+    border: 1px solid var(--tabs-border, transparentize($c-blue--darker, .9));
+    border-radius: $b-radius;
+    margin: 0 (calc(var(--tabs-gutter) * -1)) 2rem;
+    overflow: hidden;
+
+    &__content {
+        padding: var(--tabs-gutter);
+    }
+
+    &__item {
+        display: none;
+
+        &.is-active {
+            display: block;
+        }
+
+        & > :first-child {
+            margin-top: 0;
+        }
+
+        > pre,
+        > .highlight {
+            margin-left: calc(var(--tabs-gutter) * -1);
+            margin-right: calc(var(--tabs-gutter) * -1);
+            max-width: none;
+
+            &:last-child {
+                margin-bottom: calc(var(--tabs-gutter) * -1);
+            }
+        }
+    }
+
+    @include screen($screen-minimal) {
+        margin-left: 0;
+        margin-right: 0;
+    }
+
+    @include screen($screen-simple) {
+        --tabs-gutter: 30px;
+
+        &__item {
+            > pre {
+                padding-left: var(--tabs-gutter);
+                padding-right: var(--tabs-gutter);
+            }
+        }
+    }
+}

--- a/hugo/assets/scss/main.scss
+++ b/hugo/assets/scss/main.scss
@@ -44,6 +44,8 @@
 @import 'components/separator';
 @import 'components/sidenote';
 @import 'components/spinner';
+@import 'components/tabs';
+@import 'components/tabs-nav';
 @import 'components/table';
 @import 'components/teaser';
 @import 'components/toc';

--- a/hugo/assets/ts/interfaces/tabs.ts
+++ b/hugo/assets/ts/interfaces/tabs.ts
@@ -1,0 +1,9 @@
+export interface TabEventData {
+    originalElement: HTMLElement;
+    tabGroup: string;
+    tabId: string;
+}
+
+export enum TabEvents {
+    SWITCH_TAB = 'switchTab',
+}

--- a/hugo/assets/ts/main.ts
+++ b/hugo/assets/ts/main.ts
@@ -1,5 +1,5 @@
 // Helpers
-import { Docs, Drawer, Header, NotificationBar } from './widgets';
+import { Docs, Drawer, Header, NotificationBar, Tabs, TabsNav } from './widgets';
 import { scrollToHash } from './helpers/scroll-to';
 import { Widget } from './interfaces/widget';
 
@@ -11,7 +11,7 @@ declare global {
     }
 }
 
-type WidgetTypes = Docs | Drawer | Header | NotificationBar;
+type WidgetTypes = Docs | Drawer | Header | NotificationBar | Tabs | TabsNav;
 
 class App {
     public widgets: Widget[];
@@ -28,6 +28,8 @@ class App {
             [Drawer.NAME]: Drawer,
             [Header.NAME]: Header,
             [NotificationBar.NAME]: NotificationBar,
+            [Tabs.NAME]: Tabs,
+            [TabsNav.NAME]: TabsNav,
         };
 
         this.initWidgets();
@@ -38,7 +40,7 @@ class App {
         });
     }
 
-    initWidgets(container?: HTMLElement): void {
+    public initWidgets(container?: HTMLElement): void {
         const scope = container ? container : document;
 
         for (const key in this.widgetMap) {

--- a/hugo/assets/ts/widgets/index.ts
+++ b/hugo/assets/ts/widgets/index.ts
@@ -3,3 +3,5 @@ export * from './drawer';
 export * from './docs';
 export * from './header';
 export * from './notification-bar';
+export * from './tabs';
+export * from './tabs-nav';

--- a/hugo/assets/ts/widgets/tabs-nav.ts
+++ b/hugo/assets/ts/widgets/tabs-nav.ts
@@ -1,0 +1,138 @@
+import { BaseWidget } from './base-widget';
+
+export class TabsNav extends BaseWidget {
+    public static readonly NAME = 'tabs-nav';
+
+    private readonly tabList: HTMLElement;
+    private readonly paginationPrev: HTMLElement;
+    private readonly paginationNext: HTMLElement;
+
+    private showPaginationControls = false;
+    private prevDisabled = true;
+    private nextDisabled = true;
+    private scrollDistance = 0;
+
+    constructor(element: HTMLElement) {
+        super(element);
+
+        this.tabList = this.element.getElementsByClassName('tabs-nav__tabs').item(0) as HTMLElement;
+        this.paginationPrev = this.element.getElementsByClassName('tabs-nav__pagination--prev').item(0) as HTMLElement;
+        this.paginationNext = this.element.getElementsByClassName('tabs-nav__pagination--next').item(0) as HTMLElement;
+    }
+
+    public static registerWidget(): void {
+        if (window.app !== undefined) {
+            window.app.addWidget({
+                name: TabsNav.NAME,
+                load: TabsNav.attachWidgetToElements,
+            });
+        }
+    }
+
+    public static attachWidgetToElements(container: HTMLElement | Document): void {
+        const elements = container.querySelectorAll<HTMLElement>(`[data-${ TabsNav.NAME }]`);
+        elements.forEach((element) => {
+            const newWidget = new TabsNav(element);
+            newWidget.init();
+        });
+    }
+
+    public init(): void {
+        this.checkPaginationEnabled();
+
+        // Reset scroll + check for pagination on resize
+        window.addEventListener('resize', () => {
+            this.scrollDistance = 0;  // reset scroll distance
+            this.checkPaginationEnabled();
+        });
+
+        // Listen to scroll event and save position
+        this.tabList.addEventListener('scroll', () => {
+            this.scrollDistance = this.tabList.scrollLeft;
+            this.checkScrollingControls();
+        });
+
+        // Add listeners to prev & next buttons
+        this.paginationPrev.addEventListener('click', (e) => {
+            e.preventDefault();
+            this.handlePagination('prev');
+        });
+
+        this.paginationNext.addEventListener('click', (e) => {
+            e.preventDefault();
+            this.handlePagination('next');
+        });
+    }
+    public checkPaginationEnabled(): void {
+        // Calculate if tablist doesn't fit in container
+        const elemWidth = this.element.offsetWidth +
+            parseFloat(window.getComputedStyle(this.element).marginLeft) +
+            parseFloat(window.getComputedStyle(this.element).marginRight);
+
+        const isEnabled = this.tabList.scrollWidth > elemWidth;
+
+        // If pagination is not enable: reset scroll position
+        if (!isEnabled) {
+            this.scrollDistance = 0;
+            this.scrollTo(0);
+        }
+
+        // Add classes to hide/show pagination
+        this.showPaginationControls = isEnabled;
+        if (this.showPaginationControls) {
+            this.paginationPrev.classList.remove('is-hidden');
+            this.paginationNext.classList.remove('is-hidden');
+        } else {
+            this.paginationPrev.classList.add('is-hidden');
+            this.paginationNext.classList.add('is-hidden');
+        }
+
+        // Check scrolling controls again
+        this.checkScrollingControls();
+    }
+
+    public checkScrollingControls(): void {
+        if (!this.showPaginationControls) {
+            this.prevDisabled = true;
+            this.nextDisabled = true;
+        } else {
+            this.prevDisabled = this.scrollDistance === 0;
+            this.nextDisabled = this.scrollDistance >= (this.tabList.scrollWidth - this.tabList.offsetWidth);
+        }
+
+        if (this.prevDisabled) {
+            this.paginationPrev.setAttribute('disabled', '');
+        } else {
+            this.paginationPrev.removeAttribute('disabled');
+        }
+
+        if (this.nextDisabled) {
+            this.paginationNext.setAttribute('disabled', '');
+        } else {
+            this.paginationNext.removeAttribute('disabled');
+        }
+    }
+
+    public handlePagination(direction: 'next' | 'prev'): void {
+        const scrollStep = 100;
+        const scrollAmount = (direction === 'prev' ? -1 : 1) * scrollStep;
+        this.scrollTo(scrollAmount);
+    }
+
+    private scrollTo(position: number): void {
+        this.tabList.scrollBy(Math.round(position), 0);
+    }
+}
+
+if (document.readyState !== 'loading') {
+    // Ready to go!
+    TabsNav.registerWidget();
+    TabsNav.attachWidgetToElements(document);
+}
+else {
+    // Still loading, so wait...
+    document.addEventListener('DOMContentLoaded', () => {
+        TabsNav.registerWidget();
+        TabsNav.attachWidgetToElements(document);
+    });
+}

--- a/hugo/assets/ts/widgets/tabs.ts
+++ b/hugo/assets/ts/widgets/tabs.ts
@@ -1,0 +1,133 @@
+import { BaseWidget } from './base-widget';
+import { StorageService } from '../helpers/storage-service';
+import { TabEventData, TabEvents } from '../interfaces/tabs';
+
+export class Tabs extends BaseWidget {
+    public static readonly NAME = 'tabs';
+
+    private readonly tabGroup: string;
+    private readonly tabItems: NodeListOf<HTMLElement>;
+    private readonly storage: StorageService;
+
+    constructor(element: HTMLElement) {
+        super(element);
+
+        this.storage = new StorageService();
+        this.tabGroup = this.element.dataset.group;
+        // tabItems is both buttons & content
+        this.tabItems = this.element.querySelectorAll<HTMLElement>('[data-tab-group][data-tab-item]');
+    }
+
+    public static registerWidget(): void {
+        if (window.app !== undefined) {
+            window.app.addWidget({
+                name: Tabs.NAME,
+                load: Tabs.attachWidgetToElements,
+            });
+        }
+    }
+
+    public static attachWidgetToElements(container: HTMLElement | Document): void {
+        const elements = container.querySelectorAll<HTMLElement>(`[data-${ Tabs.NAME }]`);
+        elements.forEach((element) => {
+            const newWidget = new Tabs(element);
+            newWidget.init();
+        });
+    }
+
+    public init(): void {
+        // Get tabs selection from storage on load
+        this.restoreTabSelections();
+
+        // Add event on tab buttons
+        const tabButtons = this.element.querySelectorAll<HTMLElement>('button[data-tab-item]');
+        tabButtons.forEach((tab) => {
+            tab.addEventListener('click', () => {
+                this.switchTab(tab, true);
+            });
+        });
+
+        // Listen to switchTabs events from other tabs instances
+        document.addEventListener(TabEvents.SWITCH_TAB, (e: CustomEvent<TabEventData>) => {
+            if (e.detail.originalElement !== this.element && this.tabGroup === e.detail.tabGroup) {
+                const tabButton = this.element.querySelector<HTMLElement>(`button[data-tab-item="${ e.detail.tabId }"]`);
+                if (tabButton) {
+                    this.switchTab(tabButton);
+                }
+            }
+        });
+    }
+
+    public restoreTabSelections() {
+        const currentSaved = this.storage.getItem('tabSelections');
+        const tabSelections = currentSaved ? JSON.parse(currentSaved) : {};
+
+        // Loop over saved tabgroups and switch tabs to saved item ids when group matches
+        Object.keys(tabSelections).forEach((tabGroup) => {
+            const tabId = tabSelections[tabGroup];
+            if (tabGroup === this.tabGroup) {
+                const activeTab = this.element.querySelector<HTMLElement>(`button[data-tab-item="${ tabId }"]`);
+                if (activeTab) {
+                    this.switchTab(activeTab);
+                }
+            }
+        });
+    }
+
+    public switchTab(tabButton: HTMLElement, isButtonEvent = false): void {
+        const tabId = tabButton.dataset.tabItem;
+        const tabContent = this.element.querySelector<HTMLElement>(`.tabs__item[data-tab-item="${ tabId }"]`);
+
+        // Save position of current tab if is triggered from click
+        let positionTab: number = null;
+        if (isButtonEvent) {
+            positionTab = tabButton.getBoundingClientRect().top;
+        }
+
+        // Close other tabs within element
+        this.tabItems.forEach((tabItem) => {
+            tabItem.classList.remove('is-active');
+        });
+
+        // Open current tab
+        tabButton.classList.add('is-active');
+        tabContent.classList.add('is-active');
+
+        // Save to storage + dispatch events when group is not default and switchtab is called from button click
+        if (isButtonEvent && this.tabGroup !== 'default') {
+            // Save to storage when not default
+            const currentSaved = this.storage.getItem('tabSelections');
+            const tabSelections = currentSaved ? JSON.parse(currentSaved) : {};
+            tabSelections[this.tabGroup] = tabId;
+            this.storage.setItem('tabSelections', JSON.stringify(tabSelections));
+
+            // Send event to other tabs instances with same groupId if not default
+            document.dispatchEvent(new CustomEvent<TabEventData>(TabEvents.SWITCH_TAB, {
+                detail: {
+                    originalElement: this.element,
+                    tabGroup: this.tabGroup,
+                    tabId: tabId,
+                },
+            }));
+        }
+
+        // Set screen to the same position relative to clicked button to prevent page jump
+        if (isButtonEvent) {
+            const tabPositionDiff = tabButton.getBoundingClientRect().top - positionTab;
+            window.scrollTo(window.scrollX, window.scrollY + tabPositionDiff);
+        }
+    }
+}
+
+if (document.readyState !== 'loading') {
+    // Ready to go!
+    Tabs.registerWidget();
+    Tabs.attachWidgetToElements(document);
+}
+else {
+    // Still loading, so wait...
+    document.addEventListener('DOMContentLoaded', () => {
+        Tabs.registerWidget();
+        Tabs.attachWidgetToElements(document);
+    });
+}

--- a/hugo/content/en/examples/_index.html
+++ b/hugo/content/en/examples/_index.html
@@ -123,7 +123,7 @@ description: "View examples on how to use certain possible elements of the theme
                             </a>
                         </li>
                         <li class="nav__item">
-                            <a class="nav__link" href="#" disabled>
+                            <a class="nav__link" href="/examples/shortcodes/tabs">
                                 <span class="nav__text">Tabs</span>
                             </a>
                         </li>

--- a/hugo/content/en/examples/shortcodes/tabs/index.md
+++ b/hugo/content/en/examples/shortcodes/tabs/index.md
@@ -3,4 +3,156 @@ title: Tabs
 weight: 33
 ---
 
-{{< todo >}}
+You can add the tabs/tab shortcode to create tabs.
+A tab shortcode  always needs to be part of a tabs shortcode.
+
+## Usage
+
+```
+{{</* tabs */>}}
+
+{{</* tab name="Tab 1" */>}}
+Lorem ipsum dolor sit amet, alia invidunt honestatis te mea, tation docendi epicurei sit te, at qui cibo dicta temporibus.
+{{</* /tab */>}}
+
+{{</* tab name="Tab 2" */>}}
+Lorem ipsum dolor sit amet, alia invidunt honestatis te mea, tation docendi epicurei sit te, at qui cibo dicta temporibus.
+{{</* /tab */>}}
+
+{{</* /tabs */>}}
+```
+
+## Pagination controls
+
+If tabs don't fit in the current container or screen pagination controls will be shown. On touch devices you're also able to swipe.
+For example resize this screen to 320px to see this behaviour.
+
+{{< tabs >}}
+
+{{< tab name="Tab 1" >}}
+Lorem 1 ipsum dolor sit amet, alia invidunt honestatis te mea, tation docendi epicurei sit te, at qui cibo dicta temporibus.
+{{< /tab >}}
+
+{{< tab name="Tab 2" >}}
+Lorem 2 ipsum dolor sit amet, alia invidunt honestatis te mea, tation docendi epicurei sit te, at qui cibo dicta temporibus.
+{{< /tab >}}
+
+{{< tab name="Tab 3" >}}
+Lorem 3 ipsum dolor sit amet, alia invidunt honestatis te mea, tation docendi epicurei sit te, at qui cibo dicta temporibus.
+{{< /tab >}}
+
+{{< tab name="Tab 4" >}}
+Lorem 4 ipsum dolor sit amet, alia invidunt honestatis te mea, tation docendi epicurei sit te, at qui cibo dicta temporibus.
+{{< /tab >}}
+
+{{< tab name="Tab 5" >}}
+Lorem 5 ipsum dolor sit amet, alia invidunt honestatis te mea, tation docendi epicurei sit te, at qui cibo dicta temporibus.
+{{< /tab >}}
+
+{{< tab name="Tab 6" >}}
+Lorem 6 ipsum dolor sit amet, alia invidunt honestatis te mea, tation docendi epicurei sit te, at qui cibo dicta temporibus.
+{{< /tab >}}
+
+{{< /tabs >}}
+
+## Tab group syncing
+If you add a groupId the selected tab will be synced across tabs with the same groupId.
+It will also be saved to localstorage so when you refresh the page or visit it a later time the saved tabselection will be pre-selected.
+
+For instance in the example below when you click on one of the tabs both tabs instances will sync the tab selection.
+When you refresh the page or visit the page at later time the selection will be restored.
+
+If you don't add the groupId attribute or set it to 'default' the selection won't be synced and saved.
+
+The current scroll position on the page will also be saved and reset when switching tabs within a group so you don't 'jump away' when another group expands and thus pushing the content below down.
+```
+
+{{</* tabs groupId="config" */>}}
+{{</* tab name="CUE" */>}}
+Lorem ipsum dolor sit amet....
+
+```
+
+
+{{< tabs groupId="config" >}}
+{{< tab name="CUE" >}}
+Lorem ipsum dolor sit amet, alia invidunt honestatis te mea, tation docendi epicurei sit te, at qui cibo dicta temporibus.
+
+```
+firstName: "John",
+lastName: "Smith",
+age: 25,
+residence: "Amsterdam",
+occupation: "Developer"
+```
+{{< /tab >}}
+
+{{< tab name="JSON" >}}
+Lorem ipsum dolor sit amet, alia invidunt honestatis te mea, tation docendi
+epicurei sit te, at qui cibo dicta temporibus.
+
+```json
+{
+    "firstName": "John",
+    "lastName": "Smith",
+    "age": 25,
+    "residence": "Amsterdam",
+    "occupation": "Developer"
+}
+```
+{{< /tab >}}
+
+{{< tab name="YAML" >}}
+Lorem ipsum dolor sit amet, alia invidunt honestatis te mea, tation docendi epicurei sit te, at qui cibo dicta temporibus.
+
+``` yaml
+- john
+  name: John Smith
+  age: 25
+  residence: Amsterdam
+  occupation: Developer
+```
+{{< /tab >}}
+{{< /tabs >}}
+
+
+{{< tabs groupId="config">}}
+{{< tab name="CUE" >}}
+Lorem ipsum dolor sit amet, alia invidunt honestatis te mea, tation docendi epicurei sit te, at qui cibo dicta temporibus.
+
+```
+firstName: "John",
+lastName: "Smith",
+age: 25,
+residence: "Amsterdam",
+occupation: "Developer"
+```
+{{< /tab >}}
+
+{{< tab name="JSON" >}}
+Lorem ipsum dolor sit amet, alia invidunt honestatis te mea, tation docendi
+epicurei sit te, at qui cibo dicta temporibus.
+
+```json
+{
+    "firstName": "John",
+    "lastName": "Smith",
+    "age": 25,
+    "residence": "Amsterdam",
+    "occupation": "Developer"
+}
+```
+{{< /tab >}}
+
+{{< tab name="YAML" >}}
+Lorem ipsum dolor sit amet, alia invidunt honestatis te mea, tation docendi epicurei sit te, at qui cibo dicta temporibus.
+
+``` yaml
+- john
+  name: John Smith
+  age: 25
+  residence: Amsterdam
+  occupation: Developer
+```
+{{< /tab >}}
+{{< /tabs >}}

--- a/hugo/layouts/shortcodes/tab.html
+++ b/hugo/layouts/shortcodes/tab.html
@@ -1,0 +1,11 @@
+{{ if .Parent }}
+    {{ $name := trim (.Get "name") " " }}
+    {{ if not (.Parent.Scratch.Get "tabs") }}
+        {{ .Parent.Scratch.Set "tabs" slice }}
+    {{ end }}
+    {{ with .Inner }}
+        {{ $.Parent.Scratch.Add "tabs" (dict "name" $name "content" . ) }}
+    {{ end }}
+{{ else }}
+    {{- errorf "[%s] %q: tab shortcode missing its parent" site.Language.Lang .Page.Path -}}
+{{ end}}

--- a/hugo/layouts/shortcodes/tabs.html
+++ b/hugo/layouts/shortcodes/tabs.html
@@ -1,0 +1,41 @@
+{{ with .Inner }}{{/* don't do anything, just call it because hugo needs it */}}{{ end }}
+{{- $groupId := .Get "groupId" | default "default" -}}
+
+<div class="tabs" data-tabs data-group="{{ $groupId }}">
+    <div class="tabs__nav tabs-nav" data-tabs-nav>
+        <button class="tabs-nav__pagination tabs-nav__pagination--prev is-hidden">
+            <span class="tabs-nav__icon">
+                {{ partial "icon.html" (dict "class" "" "icon" "chevron-left") }}
+            </span>
+        </button>
+
+        <ul class="tabs-nav__tabs">
+            {{ range $idx, $tab := .Scratch.Get "tabs" }}
+                <li class="tabs-nav__item">
+                    <button
+                        data-tab-item="{{ .name | urlize }}"
+                        data-tab-group="{{ $groupId }}"
+                        class="tabs-nav__tab {{ cond (eq $idx 0) "is-active" ""}}"
+                    >{{ .name }}</button>
+                </li>
+            {{ end }}
+        </ul>
+
+        <button class="tabs-nav__pagination tabs-nav__pagination--next is-hidden">
+            <span class="tabs-nav__icon">
+                {{ partial "icon.html" (dict "class" "" "icon" "chevron-right") }}
+            </span>
+        </button>
+    </div>
+
+    <div class="tabs__content">
+        {{ range $idx, $tab := .Scratch.Get "tabs" }}
+            <div data-tab-item="{{ .name | urlize }}"
+                 data-tab-group="{{ $groupId }}"
+                 class="tabs__item {{ cond (eq $idx 0) "is-active" ""}}"
+            >{{ .content | markdownify }}
+            </div>
+        {{ end }}
+    </div>
+</div>
+


### PR DESCRIPTION
- Add new shortcode for tabs & tab. Tab needs to be used inside tabs
- Add html and styling for tabs
- Add javascript to tab-group do determine when we show pagination controls for when tabs don't fit inside the current container or screen, handle click events on next/prev buttons which triggers the scrolling of the tabgroup & add disabled attribute when prev/next is not needed because you can't scroll any further.
- Add javascript to handle click events on tabs. Save tab selection when group is not the default group and sync across tabs of the same group. Also save selection to localstorage and restore the tabs selection on page load.
- Add example page for tabs.

For: https://linear.app/usmedia/issue/CUE-83

Preview: https://deploy-preview-338--cue.netlify.app/examples/shortcodes/tabs/