### PR TITLE
Feat: Add category overview chapters to docs

### DIFF
--- a/hugo/content/en/docs/howto/ensure-min-max-list/index.md
+++ b/hugo/content/en/docs/howto/ensure-min-max-list/index.md
@@ -2,6 +2,8 @@
 title: Require min or max items in a list
 weight:
 draft: false
+categories:
+    - Language
 ---
 
 ## Min

--- a/hugo/content/en/docs/howto/language/index.md
+++ b/hugo/content/en/docs/howto/language/index.md
@@ -1,0 +1,7 @@
+---
+title: Language
+weight:
+draft: false
+layout: category-overview
+category: Language
+---

--- a/hugo/content/en/docs/howto/list-no-duplicates/index.md
+++ b/hugo/content/en/docs/howto/list-no-duplicates/index.md
@@ -2,6 +2,8 @@
 title: Ensure lists have no duplicate items
 weight:
 draft: false
+categories:
+    - Language
 ---
 
 In CUE, you often will work with lists of all sorts of values. To ensure a list

--- a/hugo/layouts/docs/category-overview.html
+++ b/hugo/layouts/docs/category-overview.html
@@ -1,0 +1,48 @@
+{{ define "main" }}
+    <div class="docs" data-docs>
+        <div class="docs__main">
+            {{ partial "paging/breadcrumb.html" . }}
+            {{ partial "separator.html" }}
+
+            <article class="article article--docs">
+                <div class="article__container">
+                    <header class="article__header">
+                        <h1 class="article__title">{{ .Title }}</h1>
+                    </header>
+
+                    <div class="article__content">
+                        {{ .Content }}
+
+                        {{ partial "paging/category-index.html" . }}
+                    </div>
+
+                    {{ partial "separator.html" }}
+
+                    <footer class="article__footer">
+                        {{ partial "last-modified.html" . }}
+                    </footer>
+                </div>
+            </article>
+
+            {{ partial "paging/prev-next.html" . }}
+        </div>
+        <div id="docs-menu" class="docs__aside">
+            <div class="docs__backdrop" data-docs-close="docs"></div>
+            <div class="docs__nav">
+                {{ partial "paging/tree.html" . }}
+
+                <button type="button" class="docs__hide button button--icon button--raised button--light-blue"
+                        aria-haspopup="menu" aria-expanded="false" aria-controls="docs-menu" data-docs-toggle>
+                    {{- partial "icon.html" (dict "icon" "chevron-left" "class" "button__icon") -}}
+                    <span>{{ T "ui_sidemenu_close" }}</span>
+                </button>
+            </div>
+        </div>
+
+        <button type="button" class="docs__show button button--icon button--raised button--light-blue"
+                aria-haspopup="menu" aria-expanded="false" aria-controls="docs-menu" data-docs-toggle>
+            {{- partial "icon.html" (dict "icon" "chevron-right" "class" "button__icon") -}}
+            <span>{{ T "ui_sidemenu_open" }}</span>
+        </button>
+    </div>
+{{ end }}

--- a/hugo/layouts/partials/paging/category-index.html
+++ b/hugo/layouts/partials/paging/category-index.html
@@ -1,0 +1,24 @@
+{{ $current := . -}}
+{{ $parent := .Parent -}}
+{{ $category := $current.Params.category -}}
+
+{{ $pages := (where .Site.Pages "Section" .Section).ByWeight -}}
+{{ $pages = (where $pages "Type" "!=" "search") -}}
+{{ $pages = (where $pages ".Params.hide_summary" "!=" true) -}}
+{{ $pages = (where $pages ".Parent" "!=" nil) -}}
+{{ $pages = (where $pages "Parent.File.UniqueID" "==" $parent.File.UniqueID) -}}
+{{ $pages = (where $pages ".Params.categories" "intersect" (slice $category) ) -}}
+
+{{ if not (eq (len $pages) 0) -}}
+    <nav class="nav nav--index">
+        <ul class="nav__list">
+            {{ range $pages }}
+                <li class="nav__item">
+                    <a class="nav__link" href="{{ .RelPermalink }}"{{ if .Params.disabled }} disabled{{ end }}>
+                        <span class="nav__text">{{ .LinkTitle }}</span>
+                    </a>
+                </li>
+            {{ end }}
+        </ul>
+    </nav>
+{{ end }}

--- a/hugo/layouts/partials/paging/tree.html
+++ b/hugo/layouts/partials/paging/tree.html
@@ -52,7 +52,15 @@
     {{ $isActiveChapter := .isActiveChapter -}}
     {{ $isActive := (eq $s $p) -}}
     {{ $isActivePath := ($p.IsDescendant $s) -}}
+
+    {{ $isCategoryOverview := eq $s.Params.layout "category-overview" -}}
     {{ $pages := where (union $s.Pages $s.Sections).ByWeight ".Params.toc_hide" "!=" true -}}
+
+    {{ if $isCategoryOverview }}
+        {{ $category := $s.Params.category -}}
+        {{ $pages = where (union $s.Parent.Pages $s.Parent.Sections).ByWeight ".Params.toc_hide" "!=" true -}}
+        {{ $pages = (where $pages ".Params.categories" "intersect" (slice $category) ) -}}
+    {{- end }}
 
     {{- $isPage := gt (add $depth 1) 2 }}
     {{- $isPageOfInactiveChapter := and $isPage (not $isActiveChapter) }}
@@ -70,7 +78,9 @@
             {{- $depth := add $depth 1 }}
             <ul class="tree__list {{ if gt $depth 2 }}is-page{{ else }}is-chapter{{ end }}">
                 {{ range $pages -}}
-                    {{ if (not (and (eq $s $p.Site.Home) (eq .Params.toc_root true))) -}}
+                    {{- $chapterWithCategory := and (eq $depth 2) (isset .Params "categories") }}
+                    {{- $isRoot := (and (eq $s $p.Site.Home) (eq .Params.toc_root true)) }}
+                    {{ if and (not $isRoot) (not $chapterWithCategory) -}}
                         {{ template "tree-nav-section" (dict
                             "page" $p
                             "section" .


### PR DESCRIPTION
- Add layout for category overviews which gets all pages within parent with same category as set in front-matter of the overview page and render this on the page below the content.
- Add categories to doc detail pages
- Add logic to navtree to render pages of category-chapter different because they are not nested within the section. Also make sure docs that have categories in the front-matter are not rendered in the nav tree as part of the
 normal doc flow because otherwise they will be in there twice. Note: this
 means we assume docs with a category set will also have an overview-page
 set up for that category

 Note: Hugo taxonomies (categories and tags) are still turned off. We don't
 need to turn them on for now because we only use categories in a custom way.
 Turning them on means Hugo will also generate overview pages for each
 category on a top level (/categories/language for instance) and I think we
 don't want that now.

For https://linear.app/usmedia/issue/CUE-179

Preview: https://deploy-preview-339--cue.netlify.app/docs/howto/language/
https://deploy-preview-339--cue.netlify.app/docs/howto/list-no-duplicates/