### PR TITLE
Hugo: docs spacing and typography check

### DIFF
--- a/hugo/assets/scss/base/base.scss
+++ b/hugo/assets/scss/base/base.scss
@@ -62,15 +62,19 @@ h6 {
     @include style-heading;
 
     color: var(--heading-color);
-    margin: 1rem 0 0.5rem;
+    margin: 2.5rem 0 0.5rem;
 }
 
 h1 {
     @include style-heading-1;
+
+    margin: 2.5rem 0 2rem;
 }
 
 h2 {
     @include style-heading-2;
+
+    margin: 2.5rem 0 1rem;
 }
 
 h3 {
@@ -148,7 +152,7 @@ ol {
         margin: 0 0 1.25rem;
 
         li {
-            margin: 0 0 0.5rem;
+            margin: 0 0 0.125rem;
             padding-left: 1.5rem;
             position: relative;
 
@@ -357,7 +361,7 @@ pre {
     border: 1px solid var(--pre-border-color);
     border-radius: $b-radius;
     color: var(--pre-color);
-    margin: 0 0 1rem;
+    margin: 0 0 1.5rem;
     max-width: 100%;
     overflow-x: auto;
     padding: 1rem 1.25rem;

--- a/hugo/assets/scss/components/article.scss
+++ b/hugo/assets/scss/components/article.scss
@@ -29,7 +29,6 @@
         @include style-heading-1;
 
         hyphens: auto;
-        margin-top: 0;
         word-break: break-word;
     }
 
@@ -45,30 +44,10 @@
     &--docs {
         padding-top: 0;
 
-        h1 {
-            @include style-heading-3;
-        }
-
-        h2 {
-            @include style-heading-4;
-        }
-
-        h3 {
-            @include style-heading-5;
-        }
-
         h4,
         h5,
         h6 {
             font-size: 1rem;
-        }
-
-        h1,
-        h2,
-        h3,
-        h4 {
-            margin-bottom: 0.5rem;
-            margin-top: 1.5rem;
         }
     }
 
@@ -77,16 +56,6 @@
             #{ $self }__content {
                 h2 {
                     position: relative;
-
-                    &::before {
-                        @include svg(note, $c-yellow);
-
-                        display: inline-block;
-                        height: 1.25rem;
-                        position: absolute;
-                        translate: -1.75rem 2px;
-                        width: 1.25rem;
-                    }
                 }
             }
         }

--- a/hugo/assets/scss/components/header.scss
+++ b/hugo/assets/scss/components/header.scss
@@ -113,9 +113,9 @@
                 box-shadow: $shadow--header;
                 content: '';
                 height: var(--header-logo-width);
-                left: 30px;
+                left: 35px;
                 position: absolute;
-                top: 5px;
+                top: 10px;
                 width: var(--header-logo-width);
                 z-index: 0; // Get it behind the bg
             }
@@ -168,6 +168,16 @@
 
         #{ $self }__container {
             padding: 0 $p-gutter;
+        }
+
+        &--wide,
+        &.is-sticky {
+
+            #{ $self }__container {
+                &::after {
+                    left: 40px;
+                }
+            }
         }
     }
 

--- a/hugo/assets/scss/components/tree.scss
+++ b/hugo/assets/scss/components/tree.scss
@@ -59,7 +59,7 @@
             }
 
             &.has-children {
-                margin-bottom: $p-gutter--large;
+                margin-bottom: 1.75rem;
             }
         }
 
@@ -140,8 +140,6 @@
         margin: 10px 0 0;
 
         & > #{ $self }__item {
-            margin: 0 0 6px;
-
             & > .toc {
                 margin-left: 0;
                 margin-top: 0;

--- a/hugo/assets/scss/mixins/typography.scss
+++ b/hugo/assets/scss/mixins/typography.scss
@@ -9,7 +9,7 @@
 @mixin style-text {
     font-family: $font-inter;
     font-size: 16px;
-    line-height: 1.875;
+    line-height: 1.75;
 }
 
 @mixin style-text-small {
@@ -40,56 +40,52 @@
 }
 
 @mixin style-heading-1 {
-    --heading-1-font-size: 2rem;
+    --heading-1-font-size: 2.125rem;
 
     font-size: var(--heading-1-font-size);
 
-    @include screen($screen-minimal) {
-        --heading-1-font-size: 2.25rem;
-    }
-
     @include screen($screen-simple) {
-        --heading-1-font-size: 2.75rem;
+        --heading-1-font-size: 2.5rem;
     }
 }
 
 @mixin style-heading-2 {
-    --heading-2-font-size: 1.75rem;
+    --heading-2-font-size: 1.5rem;
 
     font-size: var(--heading-2-font-size);
 
     @include screen($screen-simple) {
-        --heading-2-font-size: 2rem;
+        --heading-2-font-size: 1.625rem;
     }
 }
 
 @mixin style-heading-3 {
-    --heading-3-font-size: 1.5rem;
+    --heading-3-font-size: 1.25rem;
 
     font-size: var(--heading-3-font-size);
 
     @include screen($screen-simple) {
-        --heading-3-font-size: 1.75rem;
+        --heading-3-font-size: 1.375rem;
     }
 }
 
 @mixin style-heading-4 {
-    --heading-4-font-size: 1.25rem;
+    --heading-4-font-size: 1.125rem;
 
     font-size: var(--heading-4-font-size);
 
     @include screen($screen-simple) {
-        --heading-4-font-size: 1.5rem;
+        --heading-4-font-size: 1.25rem;
     }
 }
 
 @mixin style-heading-5 {
-    --heading-5-font-size: 1.125rem;
+    --heading-5-font-size: 1rem;
 
     font-size: var(--heading-5-font-size);
 
     @include screen($screen-simple) {
-        --heading-5-font-size: 1.25rem;
+        --heading-5-font-size: 1.125rem;
     }
 }
 


### PR DESCRIPTION
- article specific heading styling removed, now uses base style
- h1 font-size tweaks
- added margin to h1 and h2
- tree__item margin removed for chapters
- bonus: logo shadow fix on screen-simple

For: https://linear.app/usmedia/issue/CUE-188

Preview: https://deploy-preview-340--cue.netlify.app/docs/howto/encode-json-yaml-with-cue/