### PR TITLE
Hugo: Only show 3rd level nesting for active path or for active page

### DIFF
--- a/hugo/layouts/partials/paging/tree.html
+++ b/hugo/layouts/partials/paging/tree.html
@@ -52,19 +52,20 @@
     {{ $isActiveChapter := .isActiveChapter -}}
     {{ $isActive := (eq $s $p) -}}
     {{ $isActivePath := ($p.IsDescendant $s) -}}
-
     {{ $isCategoryOverview := eq $s.Params.layout "category-overview" -}}
+
     {{ $pages := where (union $s.Pages $s.Sections).ByWeight ".Params.toc_hide" "!=" true -}}
 
     {{ if $isCategoryOverview }}
         {{ $category := $s.Params.category -}}
+        {{ $isActivePath = and $isActiveChapter (in $p.Params.categories $category) -}}
         {{ $pages = where (union $s.Parent.Pages $s.Parent.Sections).ByWeight ".Params.toc_hide" "!=" true -}}
         {{ $pages = (where $pages ".Params.categories" "intersect" (slice $category) ) -}}
     {{- end }}
 
     {{- $isPage := gt (add $depth 1) 2 }}
-    {{- $isPageOfInactiveChapter := and $isPage (not $isActiveChapter) }}
-    {{ $withChildren := and (gt (len $pages) 0) (ne $depth $maxDepth) (not $isPageOfInactiveChapter) -}}
+    {{- $isPageOfInactivePath := cond $isActive false (and $isPage (not $isActivePath)) }}
+    {{ $withChildren := and (gt (len $pages) 0) (ne $depth $maxDepth) (not $isPageOfInactivePath) -}}
 
     <li class="tree__item{{ if $withChildren }} has-children{{ end }}{{ if $isActivePath }} is-active-path{{ end }}{{ if $isActive }} is-active{{ end }}">
         <a class="tree__link" href="{{ $s.RelPermalink }}" title="{{ $s.LinkTitle }}"{{ if $s.Params.disabled }} disabled{{ end }}>


### PR DESCRIPTION
- Show 3rd level nesting not when is active chapter but when is active path. So this means only full 3 levels show of current page and up. Others will just
 show 2 levels of nesting.
- Show 3rd level nesting also when current item in nav is the active page. So for example when you land on chapter Language within How-To: the third level (pages within category Language) will show.
- Add custom logic to determine if in active path when on a category page because those pages are not descendants of the category overview. They are active path when is part of current chapter and the categories match.

For: https://linear.app/usmedia/issue/CUE-206