### PR TITLE
Playground: Add tabs and make styling same as hugo code-tabs

### DIFF
--- a/hugo/layouts/_default/playground.html
+++ b/hugo/layouts/_default/playground.html
@@ -8,6 +8,7 @@
     <link rel="stylesheet" href="{{ "/playground/main.css" | relURL }}">
     <script>
         document.editorEnv = {
+            baseUrl: {{ .Site.BaseURL }},
             wasmPath: '/playground'
         }
     </script>

--- a/playground/src/components/dropdown.tsx
+++ b/playground/src/components/dropdown.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import { MouseEvent, MutableRefObject } from 'react';
 import cx from 'classnames';
+import { Icon } from './icon';
 
 export interface DropdownItem {
     value: string;
@@ -108,10 +109,9 @@ export class Dropdown extends React.Component<DropdownProps, DropdownState> {
                         (this.props.disabledText ?? 'N/A') :
                         ((this.props.buttonPrefix ?? '') + this.state.activeTitle)
                     }
-
-                    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" className="cue-button__icon">
-                        <path d="M 12.000431,13.591605 17.29716,8.2897153 a 1.0002922,1.0001653 0 0 1 1.405849,1.4231691 l -5.990903,6.0076396 a 0.99751155,0.99738496 0 0 1 -1.353349,0.02917 L 5.2978534,9.7187172 a 1.0150118,1.014883 0 0 1 -0.2975035,-0.676589 1.0441788,1.0440463 0 0 1 0.2975035,-0.7524129 0.99751155,0.99738496 0 0 1 1.4058494,0 z"/>
-                    </svg>
+                    <span className="cue-button__icon">
+                        <Icon icon="chevron-down"></Icon>
+                    </span>
                 </button>
 
                 { !this.props.disabled && this.isOpen() &&

--- a/playground/src/components/icon.tsx
+++ b/playground/src/components/icon.tsx
@@ -1,0 +1,31 @@
+import * as React from 'react';
+import cx from 'classnames';
+import { environment } from '../environment';
+
+interface IconProps {
+    cssClass?: string;
+    icon: string;
+}
+
+export class Icon extends React.Component<IconProps>
+{
+    constructor(props: IconProps) {
+        super(props);
+    }
+
+    public render() {
+        const classNames = cx(
+            'cue-icon',
+            this.props.cssClass,
+        )
+        return (
+            <svg className={ classNames } aria-hidden="true">
+                <use xmlnsXlink="http://www.w3.org/1999/xlink" xlinkHref={ this.getSpriteUrl() }></use>
+            </svg>
+        );
+    }
+
+    public getSpriteUrl(): string {
+        return `${ environment.baseUrl }/img/ui.svg#icon--${ this.props.icon }`;
+    }
+}

--- a/playground/src/components/tab.tsx
+++ b/playground/src/components/tab.tsx
@@ -1,0 +1,26 @@
+import * as React from 'react';
+import { PropsWithChildren } from 'react';
+
+export interface TabProps {
+    name: string;
+    disabled?: boolean;
+    type?: string;
+}
+
+const defaultProps = {
+    name: '',
+    disabled: false,
+    type: 'default',
+}
+
+export class Tab extends React.Component<PropsWithChildren<TabProps>> {
+    constructor(props: PropsWithChildren<TabProps>) {
+        super({ ...defaultProps, ...props, });
+    }
+
+    public render () {
+        return (
+            <div className="tabs__panel">{ this.props.children }</div>
+        );
+    }
+}

--- a/playground/src/components/tabs.tsx
+++ b/playground/src/components/tabs.tsx
@@ -1,0 +1,190 @@
+import * as React from 'react';
+import { JSXElementConstructor, MouseEvent, MutableRefObject, PropsWithChildren, ReactNode } from 'react';
+import { Icon } from './icon';
+import cx from 'classnames';
+import { Tab } from './tab';
+
+interface TabItem {
+    name: string;
+    disabled?: boolean;
+    children: ReactNode;
+    type?: string;
+}
+
+interface TabsProps {
+    activeIndex?: number;
+}
+
+interface TabsState {
+    activeIndex: number;
+    nextDisabled: boolean;
+    prevDisabled: boolean;
+    scrollDistance: number;
+    showPaginationControls: boolean;
+}
+
+export class Tabs extends React.Component<PropsWithChildren<TabsProps>, TabsState> {
+    public tabNavRef: MutableRefObject<HTMLDivElement>;
+    public tabListRef: MutableRefObject<HTMLUListElement>;
+
+    constructor(props: PropsWithChildren<TabsProps>) {
+        super(props);
+        this.tabNavRef = React.createRef<HTMLDivElement>();
+        this.tabListRef = React.createRef<HTMLUListElement>();
+
+        this.state = {
+            activeIndex: props.activeIndex ?? 0,
+            nextDisabled: true,
+            prevDisabled: true,
+            scrollDistance: 0,
+            showPaginationControls: false,
+        };
+    }
+
+    public componentDidMount() {
+        window.addEventListener('resize', this.onWindowResize.bind(this));
+
+        this.checkPaginationEnabled();
+    }
+
+    public componentWillUnmount() {
+        window.removeEventListener('resize', this.onWindowResize);
+    }
+
+    public onWindowResize() {
+        this.setState({
+            scrollDistance: 0
+        }, this.checkPaginationEnabled.bind(this));
+    }
+
+    public handleTabsScroll() {
+        this.setState({
+            scrollDistance: this.tabListRef.current.scrollLeft,
+        }, this.checkScrollingControls.bind(this));
+    }
+
+    public handlePaginationClick(e: MouseEvent, direction: 'prev' | 'next'): void {
+        e.preventDefault();
+        const scrollStep = 100;
+        const scrollAmount = (direction === 'prev' ? -1 : 1) * scrollStep;
+        this.scrollTo(scrollAmount);
+    }
+
+    public checkPaginationEnabled(): void {
+        // Calculate if tablist doesn't fit in container
+        const elemWidth = this.tabNavRef.current.offsetWidth +
+            parseFloat(window.getComputedStyle(this.tabNavRef.current).marginLeft) +
+            parseFloat(window.getComputedStyle(this.tabNavRef.current).marginRight);
+
+        const isEnabled = this.tabListRef.current.scrollWidth > elemWidth;
+
+        // If pagination is not enabled: reset scroll position
+        if (!isEnabled) {
+            this.setState({
+                scrollDistance: 0,
+                showPaginationControls: false,
+            }, this.checkScrollingControls.bind(this))
+            this.scrollTo(0);
+        } else {
+            this.setState({
+                showPaginationControls: true,
+            }, this.checkScrollingControls.bind(this))
+        }
+    }
+
+    public checkScrollingControls(): void {
+        if (!this.state.showPaginationControls) {
+            this.setState({
+                prevDisabled: true,
+                nextDisabled: true,
+            })
+        } else {
+            this.setState({
+                prevDisabled: this.state.scrollDistance === 0,
+                nextDisabled: this.state.scrollDistance >= (this.tabListRef.current.scrollWidth - this.tabListRef.current.offsetWidth),
+            })
+        }
+    }
+
+    public scrollTo(position: number): void {
+        this.tabNavRef.current.scrollBy(Math.round(position), 0);
+    }
+
+    public selectTab(e: MouseEvent, index: number) {
+        e.preventDefault();
+        this.setState({ activeIndex: index });
+    }
+
+    public render () {
+        const tabs: TabItem[] = [];
+        React.Children.forEach(this.props.children, (child) => {
+            const type = ((child as React.ReactElement).type as JSXElementConstructor<any>);
+            if (React.isValidElement(child) && (type.prototype === Tab.prototype)) {
+                tabs.push({
+                    name: child.props.name,
+                    disabled: child.props.disabled,
+                    children: child.props.children,
+                    type: child.props.type,
+                })
+            }
+        });
+
+        return (
+            <div className="cue-tabs">
+                <div className="cue-tabs__nav cue-tabs-nav" ref={ this.tabNavRef }>
+                    { this.state.showPaginationControls &&
+                        <button
+                            className="cue-tabs-nav__pagination cue-tabs-nav__pagination--prev"
+                            disabled={ this.state.prevDisabled }
+                            onClick={(e) => this.handlePaginationClick(e, 'prev')}
+                        >
+                            <span className="cue-tabs-nav__icon">
+                                <Icon icon="chevron-left"></Icon>
+                            </span>
+                        </button>
+                    }
+
+                    <ul className="cue-tabs-nav__tabs" role="tablist"
+                        ref={ this.tabListRef }
+                        onScroll={ this.handleTabsScroll.bind(this) }
+                    >
+                        { tabs.map((tab, index) =>
+                            <li className="cue-tabs-nav__item" key={`tab-${ index }`}>
+                                <button
+                                    disabled={ tab.disabled }
+                                    aria-selected={ index === this.state.activeIndex }
+                                    className={ cx('cue-tabs-nav__tab', {
+                                        'is-active': index === this.state.activeIndex,
+                                        'cue-tabs-nav__tab--terminal': tab.type === 'terminal',
+                                    }) }
+                                    onClick={ (e) => this.selectTab(e, index) }
+                                >{ tab.name }</button>
+                            </li>
+                        )}
+                    </ul>
+
+                    { this.state.showPaginationControls &&
+                        <button
+                            className="cue-tabs-nav__pagination cue-tabs-nav__pagination--next"
+                            disabled={ this.state.nextDisabled }
+                            onClick={(e) => this.handlePaginationClick(e, 'next')}
+                        >
+                            <span className="cue-tabs-nav__icon">
+                               <Icon icon="chevron-right"></Icon>
+                            </span>
+                        </button>
+                    }
+                </div>
+
+                <div className="cue-tabs__content">
+                    { tabs.map((tab, index) =>
+                        <div className={ cx('cue-tabs__item', {
+                            'is-active': index === this.state.activeIndex,
+                        }) }>{ tab.children }
+                        </div>
+                    )}
+                </div>
+            </div>
+        )
+    }
+}

--- a/playground/src/containers/app.tsx
+++ b/playground/src/containers/app.tsx
@@ -17,6 +17,8 @@ import * as acemodule from 'ace-builds';
 import { CUEVersion } from '@config/gen_cuelang_org_go_version';
 import { Dropdown, DropdownItem } from '@components/dropdown';
 import { funcOptions, inputOptions, Option, OPTION_TYPE, outputOptions } from '@models/options';
+import { Tabs } from '@components/tabs';
+import { Tab } from '@components/tab';
 
 const editorFontSize = 15;
 
@@ -133,11 +135,27 @@ export class App extends React.Component<AppProps, AppState>
                     </ul>
                     <div className="cue-playground__version">{ CUEVersion }</div>
                 </div>
-                <div className="cue-playground__column">
-                    <div className="cue-playground__code" id="lhseditor"></div>
-                </div>
-                <div className="cue-playground__column">
-                    <div className="cue-playground__code" id="rhseditor"></div>
+                <div className="cue-playground__content">
+                    <div className="cue-columns">
+                        <div className="cue-columns__item cue-columns__item--left">
+                            <Tabs>
+                                <Tab name={ `Input: ${ this.state.input.name }` }>
+                                    <div className="cue-editor">
+                                        <div id="lhseditor"></div>
+                                    </div>
+                                </Tab>
+                            </Tabs>
+                        </div>
+                        <div className="cue-columns__item cue-columns__item--right">
+                            <Tabs>
+                                <Tab name={ `Output: ${ this.state.output.name }` } type="terminal">
+                                    <div className="cue-editor cue-editor--terminal">
+                                        <div id="rhseditor"></div>
+                                    </div>
+                                </Tab>
+                            </Tabs>
+                        </div>
+                    </div>
                 </div>
             </div>
         );

--- a/playground/src/environment.ts
+++ b/playground/src/environment.ts
@@ -7,11 +7,13 @@ declare global {
 }
 
 export class Environment {
+    baseUrl: string;
     wasmPath: string;
 
     constructor() {
         const envVars = (document as DocumentEnv).editorEnv ? (document as DocumentEnv).editorEnv : {};
 
+        this.baseUrl = envVars ? String(envVars['baseUrl']) : '';
         this.wasmPath = envVars ? String(envVars['wasmPath']) : '';
     }
 }

--- a/playground/src/index.html
+++ b/playground/src/index.html
@@ -10,6 +10,7 @@
         <link rel="shortcut icon" href="/static/favicons/favicon.ico">
         <script>
             document.editorEnv = {
+                baseUrl: 'http://localhost:3000',
                 wasmPath: ''
             }
         </script>

--- a/playground/src/scss/base/fonts.scss
+++ b/playground/src/scss/base/fonts.scss
@@ -8,8 +8,8 @@
     font-family: 'Inter';
     font-style: normal;
     font-weight: 300;
-    src: url('/static/fonts/inter/300.woff2') format('woff2'), /* Chrome 36+, Opera 23+, Firefox 39+ */
-         url('/static/fonts/inter/300.woff') format('woff'); /* Chrome 5+, Firefox 3.6+, IE 9+, Safari 5.1+ */
+    src: url('/fonts/inter/300.woff2') format('woff2'), /* Chrome 36+, Opera 23+, Firefox 39+ */
+         url('/fonts/inter/300.woff') format('woff'); /* Chrome 5+, Firefox 3.6+, IE 9+, Safari 5.1+ */
   }
 
 @font-face {
@@ -18,8 +18,8 @@
     font-style: normal;
     font-weight: 400;
     src:
-        url('/static/fonts/inter/regular.woff2') format('woff2'), // Chrome 26+, Opera 23+, Firefox 39+
-        url('/static/fonts/inter/regular.woff') format('woff'); // Chrome 6+, Firefox 3.6+, IE 9+, Safari 5.1+
+        url('/fonts/inter/regular.woff2') format('woff2'), // Chrome 26+, Opera 23+, Firefox 39+
+        url('/fonts/inter/regular.woff') format('woff'); // Chrome 6+, Firefox 3.6+, IE 9+, Safari 5.1+
 }
 
 @font-face {
@@ -28,8 +28,8 @@
     font-style: normal;
     font-weight: 500;
     src:
-        url('/static/fonts/inter/500.woff2') format('woff2'), // Chrome 26+, Opera 23+, Firefox 39+
-        url('/static/fonts/inter/500.woff') format('woff'); // Chrome 6+, Firefox 3.6+, IE 9+, Safari 5.1+
+        url('/fonts/inter/500.woff2') format('woff2'), // Chrome 26+, Opera 23+, Firefox 39+
+        url('/fonts/inter/500.woff') format('woff'); // Chrome 6+, Firefox 3.6+, IE 9+, Safari 5.1+
 }
 
 @font-face {
@@ -38,8 +38,8 @@
     font-style: normal;
     font-weight: 600;
     src:
-        url('/static/fonts/inter/600.woff2') format('woff2'), // Chrome 26+, Opera 23+, Firefox 39+
-        url('/static/fonts/inter/600.woff') format('woff'); // Chrome 6+, Firefox 3.6+, IE 9+, Safari 5.1+
+        url('/fonts/inter/600.woff2') format('woff2'), // Chrome 26+, Opera 23+, Firefox 39+
+        url('/fonts/inter/600.woff') format('woff'); // Chrome 6+, Firefox 3.6+, IE 9+, Safari 5.1+
 }
 
 @font-face {
@@ -48,8 +48,8 @@
     font-style: normal;
     font-weight: 700;
     src:
-        url('/static/fonts/inter/700.woff2') format('woff2'), // Chrome 26+, Opera 23+, Firefox 39+
-        url('/static/fonts/inter/700.woff') format('woff'); // Chrome 6+, Firefox 3.6+, IE 9+, Safari 5.1+
+        url('/fonts/inter/700.woff2') format('woff2'), // Chrome 26+, Opera 23+, Firefox 39+
+        url('/fonts/inter/700.woff') format('woff'); // Chrome 6+, Firefox 3.6+, IE 9+, Safari 5.1+
 }
 
 @font-face {
@@ -58,7 +58,7 @@
     font-style: normal;
     font-weight: 400;
     src:
-        url('/static/fonts/roboto-mono/regular.woff2') format('woff2'), // Chrome 26+, Opera 23+, Firefox 39+
-        url('/static/fonts/roboto-mono/regular.woff') format('woff'); // Chrome 6+, Firefox 3.6+, IE 9+, Safari 5.1+
+        url('/fonts/roboto-mono/regular.woff2') format('woff2'), // Chrome 26+, Opera 23+, Firefox 39+
+        url('/fonts/roboto-mono/regular.woff') format('woff'); // Chrome 6+, Firefox 3.6+, IE 9+, Safari 5.1+
 }
 

--- a/playground/src/scss/components/button.scss
+++ b/playground/src/scss/components/button.scss
@@ -4,7 +4,7 @@
 
 .#{ $prefix }-button {
     align-items: center;
-    background: $c-blue--light;
+    background: $c-blue--darker;
     border-radius: 30px;
     color: $c-white;
     display: inline-flex;
@@ -25,7 +25,7 @@
 
     &:focus-visible,
     &:hover {
-        background-color: $c-blue--darker;
+        background-color: $c-blue;
     }
 
     &:disabled {

--- a/playground/src/scss/components/columns.scss
+++ b/playground/src/scss/components/columns.scss
@@ -1,0 +1,89 @@
+@import '../config/colors';
+@import '../config/prefix';
+@import '../config/sizes';
+@import '../mixins/screen';
+
+.#{ $prefix }-columns {
+    border: 2px solid $c-grey-blue;
+    display: grid;
+    grid-template:
+        'topLeft topRight' 50% / 100%
+        'bottomLeft bottomRight' 50% / 100%;
+
+    &__item {
+        border-bottom: 2px solid $c-grey-blue;
+
+        &:last-child {
+            border-bottom: 0;
+        }
+
+        .#{ $prefix }-tabs,
+        pre {
+            border: 0;
+            height: 100%;
+            margin: 0;
+        }
+    }
+
+    @include screen($screen-simple) {
+        grid-template:
+            'topLeft topRight' 50%
+            'bottomLeft bottomRight' 50% / 50% 50%;
+
+        &__item {
+            &:only-child {
+                grid-column: span 2;
+            }
+
+            &--left {
+                border-bottom: 0;
+                grid-area: topLeft;
+                grid-row: span 2;
+                resize: horizontal;
+            }
+
+            &--right {
+                border-bottom: 0;
+                border-left: 2px solid $c-grey-blue;
+                grid-area: topRight;
+                grid-row: span 2;
+            }
+
+            &--top-left {
+                grid-area: topLeft;
+
+                &:nth-last-child(2) {
+                    grid-column: span 2;
+                }
+            }
+
+            &--bottom-left {
+                border-bottom: 0;
+                grid-area: bottomLeft;
+
+                &:last-child {
+                    grid-column: span 2;
+                }
+            }
+
+            &--top-right {
+                border-left: 2px solid $c-grey-blue;
+                grid-area: topRight;
+
+                &:first-child {
+                    grid-column: span 2;
+                }
+            }
+
+            &--bottom-right {
+                border-bottom: 0;
+                border-left: 2px solid $c-grey-blue;
+                grid-area: bottomRight;
+
+                &:nth-child(2) {
+                    grid-column: span 2;
+                }
+            }
+        }
+    }
+}

--- a/playground/src/scss/components/editor.scss
+++ b/playground/src/scss/components/editor.scss
@@ -1,0 +1,27 @@
+@import '../config/colors';
+@import '../config/prefix';
+
+.#{ $prefix }-editor {
+    background: $c-white;
+    height: 100%;
+    padding: .875rem 0;
+    width: 100%;
+
+    > * {
+        height: 100%;
+    }
+
+    .ace_gutter {
+        background: $c-white !important;
+    }
+
+    &--terminal {
+        background: $c-grey-blue--lighter;
+
+        .ace_editor,
+        .ace_gutter {
+            background: $c-grey-blue--lighter !important;
+        }
+
+    }
+}

--- a/playground/src/scss/components/icon.scss
+++ b/playground/src/scss/components/icon.scss
@@ -1,0 +1,9 @@
+@import '../config/prefix';
+
+.#{ $prefix }-icon {
+    display: block;
+    fill: currentColor;
+    height: 100%;
+    transition: fill 0.2s;
+    width: 100%;
+}

--- a/playground/src/scss/components/playground.scss
+++ b/playground/src/scss/components/playground.scss
@@ -8,16 +8,14 @@
 .#{ $prefix }-playground {
     display: grid;
     font-family: $font-inter;
-    grid-gap: 10px;
-    grid-template-columns: 1fr 1fr;
+    grid-template-columns: 1fr;
     grid-template-rows: auto 1fr;
     height: 100%;
-    padding-bottom: 10px;
     width: 100%;
 
     &__header {
         align-items: center;
-        background-color: $c-blue--lighter;
+        background-color: $c-grey-blue--lighter;
         display: flex;
         flex-direction: row;
         gap: 0.3rem;
@@ -36,25 +34,14 @@
 
     &__version {
         align-self: flex-start;
-        color: $c-blue;
+        color: $c-blue--darker;
         font-size: 0.875rem;
         margin-top: 0.5rem;
     }
 
-    &__column {
-        background-color: $c-blue--lighter;
-        border-radius: $b-radius;
-        overflow: hidden;
-        padding: 1.5rem 1rem;
-    }
-
-    &__code {
-        background: $c-blue--lighter !important;
-        height: 100%;
-        width: 100%;
-
-        .ace_gutter {
-            background: $c-blue--lighter !important;
+    &__content {
+        > * {
+            height: 100%;
         }
     }
 

--- a/playground/src/scss/components/tabs-nav.scss
+++ b/playground/src/scss/components/tabs-nav.scss
@@ -1,0 +1,117 @@
+@import '../config/colors';
+@import '../config/prefix';
+@import '../config/sizes';
+@import '../config/typography';
+@import '../mixins/list-reset';
+@import '../mixins/stretch';
+
+.#{ $prefix }-tabs-nav {
+    $self: &;
+
+    background-color: $c-grey-blue--lighter;
+    display: flex;
+    overflow: hidden;
+
+    &__tabs {
+        @include list-reset;
+
+        display: flex;
+        overflow-x: auto;
+        scroll-behavior: smooth;
+        scrollbar-width: none;
+    }
+
+    &__item {
+        flex: 0 0 auto;
+    }
+
+    &__tab {
+        background-color: var(--tab-background, $c-white);
+        color: var(--tab-color, $c-blue--darker);
+        display: block;
+        font-size: 0.75rem;
+        font-weight: $weight-medium;
+        height: 35px;
+        line-height: 35px;
+        padding: 0 1rem;
+        position: relative;
+        text-align: center;
+        transition: color .2s, background-color .2s;
+
+        &:focus,
+        &:hover {
+            background-color: var(--tab-background-hover, $c-grey-blue--light);
+        }
+
+        &:disabled {
+            color: $c-grey--dark;
+            pointer-events: none;
+        }
+
+        &.is-active {
+            background-color: var(--tab-background-active, $c-white);
+            font-weight: $weight-bold;
+            pointer-events: none;
+        }
+
+        &--terminal {
+            --tab-background: #{ $c-grey-blue--lighter };
+            --tab-background-hover: #{ $c-grey-blue--light };
+            --tab-background-active: #{ $c-grey-blue--lighter };
+
+            font-weight: $weight-semibold;
+        }
+    }
+
+    &__pagination {
+        align-items: center;
+        box-shadow:
+            0 2px 4px -1px transparentize($c-black, .8),
+            0 4px 5px 0 transparentize($c-black, .86),
+            0 1px 10px 0 transparentize($c-black, .88);
+        color: $c-black;
+        display: flex;
+        flex: 0 0 36px;
+        justify-content: center;
+        overflow: hidden;
+        position: relative;
+        width: 36px;
+
+        &::before {
+            @include stretch;
+
+            background-color: transparentize($c-grey--lighter, .5);
+            border-radius: 20px;
+            content: '';
+            display: block;
+            height: 140%;
+            pointer-events: none;
+            transform: scale(0) translate(-20%, -20%);
+            transform-origin: left bottom;
+            transition: transform .2s;
+            width: 140%;
+        }
+
+        &:focus,
+        &:hover {
+            color: $c-grey--dark;
+
+            &::before {
+                transform: scale(1) translate(-20%, -20%);
+            }
+        }
+
+        &:disabled {
+            box-shadow: none;
+            color: $c-grey--light;
+            pointer-events: none;
+        }
+    }
+
+    &__icon {
+        display: block;
+        height: 24px;
+        position: relative;
+        width: 24px;
+    }
+}

--- a/playground/src/scss/components/tabs.scss
+++ b/playground/src/scss/components/tabs.scss
@@ -1,0 +1,32 @@
+@import '../config/colors';
+@import '../config/prefix';
+
+.#{ $prefix }-tabs {
+    $self: &;
+
+    display: flex;
+    flex-direction: column;
+
+    &__content {
+        background-color: $c-white;
+        flex: 1 1 auto;
+        overflow-y: auto;
+        padding: 0;
+
+        > * {
+            height: 100%;
+        }
+    }
+
+    &__nav {
+        flex: 0 0 auto;
+    }
+
+    &__item {
+        display: none;
+
+        &.is-active {
+            display: block;
+        }
+    }
+}

--- a/playground/src/scss/config/colors.scss
+++ b/playground/src/scss/config/colors.scss
@@ -5,6 +5,10 @@ $c-blue:                #232a68;
 $c-blue--dark:          #0c2c65;
 $c-blue--darker:        #0f1333;
 
+$c-grey-blue--lighter:  #f1f2f6;
+$c-grey-blue--light:    #e7e8ee;
+$c-grey-blue:           #e0e2eb;
+
 $c-red--lighter:        #ffbcbc;
 $c-red--light:          #de4a4b;
 $c-red:                 #ed1c24;

--- a/playground/src/scss/main.scss
+++ b/playground/src/scss/main.scss
@@ -1,4 +1,9 @@
 @import 'components/button';
+@import 'components/columns';
 @import 'components/dropdown';
+@import 'components/editor';
+@import 'components/icon';
 @import 'components/playground';
 @import 'components/share';
+@import 'components/tabs';
+@import 'components/tabs-nav';

--- a/playground/src/scss/mixins/stretch.scss
+++ b/playground/src/scss/mixins/stretch.scss
@@ -1,0 +1,7 @@
+@mixin stretch {
+    height: 100%;
+    left: 0;
+    position: absolute;
+    top: 0;
+    width: 100%;
+}

--- a/playground/webpack.config.js
+++ b/playground/webpack.config.js
@@ -29,7 +29,7 @@ module.exports = (env, argv) => {
         },
         cache: {
             type: 'filesystem',
-						cacheDirectory: path.resolve(__dirname, '.webpack_cache'),
+            cacheDirectory: path.resolve(__dirname, '.webpack_cache'),
         },
         plugins: [
             new HtmlWebpackPlugin({


### PR DESCRIPTION
- Create React Tabs component & tab subcomponent
- Tabs-nav logic for showing/hiding pagination (same functionality as hugo tabs-nav but now reactive)
- Create icon component so we can easily use icons from spritesheet in the react app.
- Add base url to env because it's needed for the icon spritesheet which needs absolute url to the main svg
- Handle select tab events and display right content
- Add tabs & tabnav styling (similar to hugo site)
- Move editor scss to separate scss
- Render editors inside of tabs
- Change styling of editor & playground
- Style right editor with 'terminal' styles (blue background)
- Fix font paths for local development playground
- Fix indenting in webpack.config.js

For: https://linear.app/usmedia/issue/CUE-214
and: https://linear.app/usmedia/issue/CUE-219