### PR TITLE
Hugo: no italics on search results page

### DIFF
--- a/hugo/assets/scss/components/teaser.scss
+++ b/hugo/assets/scss/components/teaser.scss
@@ -67,11 +67,6 @@
         border-bottom: 1px solid transparentize($c-blue--darker, 0.8);
         border-radius: 0;
 
-        em {
-            color: $c-pink;
-            font-weight: $weight-bold;
-        }
-
         #{ $self }__title {
             margin: 0;
         }
@@ -81,7 +76,6 @@
         }
 
         #{ $self }__excerpt {
-            font-style: italic;
             font-weight: $weight-medium;
             margin: 0.5rem 0 0;
         }


### PR DESCRIPTION
- removed the italics style from the teaser excerpt
- in Algolia: set highlight code from <em> to <mark>

For feature/cue-225-search-summary-text-on-results-page-not-in-italics