### PR TITLE
Playground: Monaco Editor

### DIFF
--- a/playground/package-lock.json
+++ b/playground/package-lock.json
@@ -8,14 +8,16 @@
       "name": "CUEplayground",
       "version": "0.1.0",
       "dependencies": {
+        "@monaco-editor/react": "4.5.1",
+        "lodash.debounce": "4.0.8",
         "react": "18.2.0",
         "react-dom": "18.2.0",
         "react-scripts": "5.0.1"
       },
       "devDependencies": {
+        "@types/lodash.debounce": "4.0.7",
         "@types/react": "18.0.28",
         "@types/react-dom": "18.0.10",
-        "ace-builds": "1.15.0",
         "classnames": "2.3.2",
         "copy-webpack-plugin": "11.0.0",
         "css-loader": "6.7.3",
@@ -2587,6 +2589,30 @@
       "version": "2.0.4",
       "license": "MIT"
     },
+    "node_modules/@monaco-editor/loader": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/@monaco-editor/loader/-/loader-1.3.3.tgz",
+      "integrity": "sha512-6KKF4CTzcJiS8BJwtxtfyYt9shBiEv32ateQ9T4UVogwn4HM/uPo9iJd2Dmbkpz8CM6Y0PDUpjnZzCwC+eYo2Q==",
+      "dependencies": {
+        "state-local": "^1.0.6"
+      },
+      "peerDependencies": {
+        "monaco-editor": ">= 0.21.0 < 1"
+      }
+    },
+    "node_modules/@monaco-editor/react": {
+      "version": "4.5.1",
+      "resolved": "https://registry.npmjs.org/@monaco-editor/react/-/react-4.5.1.tgz",
+      "integrity": "sha512-NNDFdP+2HojtNhCkRfE6/D6ro6pBNihaOzMbGK84lNWzRu+CfBjwzGt4jmnqimLuqp5yE5viHS2vi+QOAnD5FQ==",
+      "dependencies": {
+        "@monaco-editor/loader": "^1.3.3"
+      },
+      "peerDependencies": {
+        "monaco-editor": ">= 0.25.0 < 1",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0",
+        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0"
+      }
+    },
     "node_modules/@nicolo-ribaudo/eslint-scope-5-internals": {
       "version": "5.1.1-v1",
       "license": "MIT",
@@ -3185,6 +3211,21 @@
       "version": "0.0.29",
       "license": "MIT"
     },
+    "node_modules/@types/lodash": {
+      "version": "4.14.195",
+      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.195.tgz",
+      "integrity": "sha512-Hwx9EUgdwf2GLarOjQp5ZH8ZmblzcbTBC2wtQWNKARBSxM9ezRIAUpeDTgoQRAFB0+8CNWXVA9+MaSOzOF3nPg==",
+      "dev": true
+    },
+    "node_modules/@types/lodash.debounce": {
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/@types/lodash.debounce/-/lodash.debounce-4.0.7.tgz",
+      "integrity": "sha512-X1T4wMZ+gT000M2/91SYj0d/7JfeNZ9PeeOldSNoE/lunLeQXKvkmIumI29IaKMotU/ln/McOIvgzZcQ/3TrSA==",
+      "dev": true,
+      "dependencies": {
+        "@types/lodash": "*"
+      }
+    },
     "node_modules/@types/mime": {
       "version": "3.0.1",
       "license": "MIT"
@@ -3773,11 +3814,6 @@
       "engines": {
         "node": ">= 0.6"
       }
-    },
-    "node_modules/ace-builds": {
-      "version": "1.15.0",
-      "dev": true,
-      "license": "BSD-3-Clause"
     },
     "node_modules/acorn": {
       "version": "8.8.0",
@@ -9717,6 +9753,12 @@
         "mkdirp": "bin/cmd.js"
       }
     },
+    "node_modules/monaco-editor": {
+      "version": "0.38.0",
+      "resolved": "https://registry.npmjs.org/monaco-editor/-/monaco-editor-0.38.0.tgz",
+      "integrity": "sha512-11Fkh6yzEmwx7O0YoLxeae0qEGFwmyPRlVxpg7oF9czOOCB/iCjdJrG5I67da5WiXK3YJCxoz9TJFE8Tfq/v9A==",
+      "peer": true
+    },
     "node_modules/ms": {
       "version": "2.0.0",
       "license": "MIT"
@@ -12655,6 +12697,11 @@
     "node_modules/stackframe": {
       "version": "1.3.4",
       "license": "MIT"
+    },
+    "node_modules/state-local": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/state-local/-/state-local-1.0.7.tgz",
+      "integrity": "sha512-HTEHMNieakEnoe33shBYcZ7NX83ACUjCu8c40iOGEZsngj9zRnkqS9j1pqQPXwobB0ZcVTk27REb7COQ0UR59w=="
     },
     "node_modules/statuses": {
       "version": "2.0.1",
@@ -15910,6 +15957,22 @@
     "@leichtgewicht/ip-codec": {
       "version": "2.0.4"
     },
+    "@monaco-editor/loader": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/@monaco-editor/loader/-/loader-1.3.3.tgz",
+      "integrity": "sha512-6KKF4CTzcJiS8BJwtxtfyYt9shBiEv32ateQ9T4UVogwn4HM/uPo9iJd2Dmbkpz8CM6Y0PDUpjnZzCwC+eYo2Q==",
+      "requires": {
+        "state-local": "^1.0.6"
+      }
+    },
+    "@monaco-editor/react": {
+      "version": "4.5.1",
+      "resolved": "https://registry.npmjs.org/@monaco-editor/react/-/react-4.5.1.tgz",
+      "integrity": "sha512-NNDFdP+2HojtNhCkRfE6/D6ro6pBNihaOzMbGK84lNWzRu+CfBjwzGt4jmnqimLuqp5yE5viHS2vi+QOAnD5FQ==",
+      "requires": {
+        "@monaco-editor/loader": "^1.3.3"
+      }
+    },
     "@nicolo-ribaudo/eslint-scope-5-internals": {
       "version": "5.1.1-v1",
       "requires": {
@@ -16253,6 +16316,21 @@
     },
     "@types/json5": {
       "version": "0.0.29"
+    },
+    "@types/lodash": {
+      "version": "4.14.195",
+      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.195.tgz",
+      "integrity": "sha512-Hwx9EUgdwf2GLarOjQp5ZH8ZmblzcbTBC2wtQWNKARBSxM9ezRIAUpeDTgoQRAFB0+8CNWXVA9+MaSOzOF3nPg==",
+      "dev": true
+    },
+    "@types/lodash.debounce": {
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/@types/lodash.debounce/-/lodash.debounce-4.0.7.tgz",
+      "integrity": "sha512-X1T4wMZ+gT000M2/91SYj0d/7JfeNZ9PeeOldSNoE/lunLeQXKvkmIumI29IaKMotU/ln/McOIvgzZcQ/3TrSA==",
+      "dev": true,
+      "requires": {
+        "@types/lodash": "*"
+      }
     },
     "@types/mime": {
       "version": "3.0.1"
@@ -16621,10 +16699,6 @@
         "mime-types": "~2.1.34",
         "negotiator": "0.6.3"
       }
-    },
-    "ace-builds": {
-      "version": "1.15.0",
-      "dev": true
     },
     "acorn": {
       "version": "8.8.0"
@@ -20224,6 +20298,12 @@
         "minimist": "^1.2.6"
       }
     },
+    "monaco-editor": {
+      "version": "0.38.0",
+      "resolved": "https://registry.npmjs.org/monaco-editor/-/monaco-editor-0.38.0.tgz",
+      "integrity": "sha512-11Fkh6yzEmwx7O0YoLxeae0qEGFwmyPRlVxpg7oF9czOOCB/iCjdJrG5I67da5WiXK3YJCxoz9TJFE8Tfq/v9A==",
+      "peer": true
+    },
     "ms": {
       "version": "2.0.0"
     },
@@ -21810,6 +21890,11 @@
     },
     "stackframe": {
       "version": "1.3.4"
+    },
+    "state-local": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/state-local/-/state-local-1.0.7.tgz",
+      "integrity": "sha512-HTEHMNieakEnoe33shBYcZ7NX83ACUjCu8c40iOGEZsngj9zRnkqS9j1pqQPXwobB0ZcVTk27REb7COQ0UR59w=="
     },
     "statuses": {
       "version": "2.0.1"

--- a/playground/package.json
+++ b/playground/package.json
@@ -5,14 +5,16 @@
   "author": "",
   "main": "index.js",
   "dependencies": {
+    "lodash.debounce": "4.0.8",
+    "@monaco-editor/react": "4.5.1",
     "react": "18.2.0",
     "react-dom": "18.2.0",
     "react-scripts": "5.0.1"
   },
   "devDependencies": {
+    "@types/lodash.debounce": "4.0.7",
     "@types/react": "18.0.28",
     "@types/react-dom": "18.0.10",
-    "ace-builds": "1.15.0",
     "css-loader": "6.7.3",
     "classnames": "2.3.2",
     "copy-webpack-plugin": "11.0.0",

--- a/playground/src/components/tabs.tsx
+++ b/playground/src/components/tabs.tsx
@@ -178,7 +178,7 @@ export class Tabs extends React.Component<PropsWithChildren<TabsProps>, TabsStat
 
                 <div className="cue-tabs__content">
                     { tabs.map((tab, index) =>
-                        <div className={ cx('cue-tabs__item', {
+                        <div key={`tab-content-${ index }`}  className={ cx('cue-tabs__item', {
                             'is-active': index === this.state.activeIndex,
                         }) }>{ tab.children }
                         </div>

--- a/playground/src/config/monaco-editor.ts
+++ b/playground/src/config/monaco-editor.ts
@@ -1,0 +1,16 @@
+import { editor } from 'monaco-editor';
+
+export const editorOptions: editor.IStandaloneEditorConstructionOptions = {
+    automaticLayout: true,
+    minimap: {
+        enabled: false,
+    },
+    renderLineHighlight: 'none',
+    scrollBeyondLastLine: false,
+}
+
+export const outputEditorOptions: editor.IStandaloneEditorConstructionOptions = {
+    ...editorOptions,
+    domReadOnly: true,
+    readOnly: true,
+}

--- a/playground/src/index.html
+++ b/playground/src/index.html
@@ -7,7 +7,7 @@
         <title>CUE Playground</title>
         <link rel="stylesheet" href="dev.css">
         <link rel="stylesheet" href="main.css">
-        <link rel="shortcut icon" href="/static/favicons/favicon.ico">
+        <link rel="shortcut icon" href="/favicons/favicon.ico">
         <script>
             document.editorEnv = {
                 baseUrl: 'http://localhost:3000',

--- a/playground/src/scss/components/columns.scss
+++ b/playground/src/scss/components/columns.scss
@@ -9,6 +9,8 @@
     grid-template:
         'topLeft topRight' 50% / 100%
         'bottomLeft bottomRight' 50% / 100%;
+    max-height: 100vh;
+    max-width: 100vw;
 
     &__item {
         border-bottom: 2px solid $c-grey-blue;

--- a/playground/src/scss/components/editor.scss
+++ b/playground/src/scss/components/editor.scss
@@ -2,26 +2,18 @@
 @import '../config/prefix';
 
 .#{ $prefix }-editor {
-    background: $c-white;
-    height: 100%;
-    padding: .875rem 0;
-    width: 100%;
-
-    > * {
-        height: 100%;
-    }
-
-    .ace_gutter {
-        background: $c-white !important;
-    }
+    background: $c-white-vscode;
+    padding-top: 1rem;
 
     &--terminal {
         background: $c-grey-blue--lighter;
 
-        .ace_editor,
-        .ace_gutter {
-            background: $c-grey-blue--lighter !important;
+        .monaco-editor {
+            --vscode-editor-background: #{ $c-grey-blue--lighter };
+            --vscode-breadcrumb-background: #{ $c-grey-blue--lighter };
+            --vscode-editorGutter-background: #{ $c-grey-blue--lighter };
+            --vscode-editorMarkerNavigation-background: #{ $c-grey-blue--lighter };
+            --vscode-editorStickyScroll-background: #{ $c-grey-blue--lighter };
         }
-
     }
 }

--- a/playground/src/scss/components/tabs-nav.scss
+++ b/playground/src/scss/components/tabs-nav.scss
@@ -26,7 +26,7 @@
     }
 
     &__tab {
-        background-color: var(--tab-background, $c-white);
+        background-color: var(--tab-background, $c-white-vscode);
         color: var(--tab-color, $c-blue--darker);
         display: block;
         font-size: 0.75rem;
@@ -49,7 +49,7 @@
         }
 
         &.is-active {
-            background-color: var(--tab-background-active, $c-white);
+            background-color: var(--tab-background-active, $c-white-vscode);
             font-weight: $weight-bold;
             pointer-events: none;
         }

--- a/playground/src/scss/components/tabs.scss
+++ b/playground/src/scss/components/tabs.scss
@@ -8,7 +8,7 @@
     flex-direction: column;
 
     &__content {
-        background-color: $c-white;
+        background-color: $c-white-vscode;
         flex: 1 1 auto;
         overflow-y: auto;
         padding: 0;

--- a/playground/src/scss/config/colors.scss
+++ b/playground/src/scss/config/colors.scss
@@ -21,6 +21,7 @@ $c-yellow--dark:        #dcab27;
 $c-pink:                #ff007f;
 
 $c-white:               #fff;
+$c-white-vscode:        #fffffe;
 $c-black:               #000;
 
 $c-grey--lightest:      #f8f9fd;

--- a/playground/webpack.config.js
+++ b/playground/webpack.config.js
@@ -59,6 +59,10 @@ module.exports = (env, argv) => {
                     loader: 'ts-loader'
                 },
                 {
+                    test: /\.css$/,
+                    use: ['style-loader', 'css-loader'],
+                },
+                {
                     test: /\.scss$/,
                     use: [
                         {


### PR DESCRIPTION
- Remove ace-editor and replace with monaco editor
- Put config files for input/output  options editor in config folder
- On window resize recalculate editor sizes using layout() function
- Remove loadEditor function, move settings option to the editor config files.
- Move getting id and loading code from database to its own function
- Add css loader for .css files so Monaco styles can be loaded
- Overrule some css variables for monaco-editor to be able to change the background color of the output editor. Monaco only support 1 theme for the entire page/app so we can't use Monaco Theme's to change 1 editor only.
- Use vscode-light theme white for tabs backgrounds so the white is the same as the vscode-theme.
- Wait until editor loaded to get saved Code + update output
- Add deboucing to the inputhandler on the input-editor to avoid editor getting super slow because it has to handle each typed character.
- Fix issue with tabs content items missing a key which react wants to have.