### PR TITLE
Hugo/Playground: Fix playground icons

### DIFF
--- a/hugo/layouts/_default/playground.html
+++ b/hugo/layouts/_default/playground.html
@@ -8,7 +8,7 @@
     <link rel="stylesheet" href="{{ "/playground/main.css" | relURL }}">
     <script>
         document.editorEnv = {
-            baseUrl: {{ .Site.BaseURL }},
+            baseUrl: {{ .Site.BaseURL | absURL }},
             wasmPath: '/playground'
         }
     </script>


### PR DESCRIPTION
- Use absUrl pipe on hugo side to get the absolute url of the site which is needed to render the icons from the svg sprite.

Note: Local and preview did not have this problem, just production (alpha). 
Hopefully this fixes it and it will now get the absolute baseUrl. If not we have to look into the hugo variables for prod.