### PR TITLE
Playground: Fix playground icons

### DIFF
--- a/playground/src/components/icon.tsx
+++ b/playground/src/components/icon.tsx
@@ -26,6 +26,7 @@ export class Icon extends React.Component<IconProps>
     }
 
     public getSpriteUrl(): string {
-        return `${ environment.baseUrl }/img/ui.svg#icon--${ this.props.icon }`;
+        const baseUrl = environment.baseUrl;
+        return `${ baseUrl }${ baseUrl.endsWith('/') ? '' : '/' }img/ui.svg#icon--${ this.props.icon }`;
     }
 }


### PR DESCRIPTION
- Absolute url can have a trailing slash depending on the environment (local, preview, alpha) so added an extra check to see if we need a slash between baseUrl and img path in the playground spritesheet url.