### PR TITLE
Search - Add more search attributes to index object

### DIFF
--- a/hugo/assets/ts/interfaces/search.ts
+++ b/hugo/assets/ts/interfaces/search.ts
@@ -2,8 +2,10 @@ export interface SearchItem {
     objectID: string;
     title: string;
     link: string;
-    categories: string | string[];
     summary: string;
     publishDate: string;
     content: string;
+    section: string;
+    categories: string | string[];
+    tags: string | string[];
 }

--- a/hugo/assets/ts/interfaces/teaser.ts
+++ b/hugo/assets/ts/interfaces/teaser.ts
@@ -1,6 +1,6 @@
 export interface Teaser {
     title: string;
     link: string;
-    categories: string | string[];
     summary: string;
+    categories: string | string[];
 }

--- a/hugo/assets/ts/widgets/search-results.ts
+++ b/hugo/assets/ts/widgets/search-results.ts
@@ -74,8 +74,8 @@ export class SearchResults extends BaseWidget {
         return {
             title: hit._highlightResult.title.value,
             link: hit.link,
-            categories: hit.categories,
             summary: hit._snippetResult.summary.value,
+            categories: hit.categories,
         };
     }
 

--- a/hugo/layouts/_default/list.algolia.json
+++ b/hugo/layouts/_default/list.algolia.json
@@ -23,10 +23,12 @@
     {{- $objectID := (print $page.File.UniqueID "_" (add $index 1)) -}}
     {{- $title :=  $page.Title -}}
     {{- $link := $page.RelPermalink -}}
-    {{- $categories := cond (isset $page.Params "categories") ($page.Params.categories) "" -}}
     {{- $publishDate := $page.PublishDate -}}
     {{- $summary := $page.Summary -}}
     {{- $content := "" -}}
+    {{- $section := $page.Section -}}
+    {{- $categories := cond (isset $page.Params "categories") ($page.Params.categories) "" -}}
+    {{- $tags := cond (isset $page.Params "tags") ($page.Params.tags) "" -}}
 
     {{- if eq $index 0 -}}
         {{- $content = delimit (first $cutoff $page.PlainWords) " " -}}
@@ -37,11 +39,13 @@
     {
         "objectID": {{ $objectID | jsonify }},
         "title": {{ $title | jsonify }},
-        "categories": {{ $categories | jsonify }},
         "link": {{ $link | jsonify }},
         "publishDate": {{ $publishDate | jsonify }},
         "summary": {{ $summary | jsonify }},
-        "content": {{ $content  | jsonify}}
+        "content": {{ $content  | jsonify}},
+        "section": {{ $section | jsonify }},
+        "categories": {{ $categories | jsonify }},
+        "tags": {{ $tags | jsonify }}
     }
 
     {{- if gt $page.PlainWords (add $cutoff $skipWords) -}},


### PR DESCRIPTION
- Add search attribute for tags & section (blog/docs)
- Change order of object keys so 'filters' are last

For: https://linear.app/usmedia/issue/CUE-235