### PR TITLE
Hugo: Make anchor keyboard accessible

### DIFF
--- a/hugo/assets/scss/components/anchor.scss
+++ b/hugo/assets/scss/components/anchor.scss
@@ -1,3 +1,4 @@
+@import '../config/sizes';
 @import '../mixins/screen';
 
 .anchor {
@@ -7,6 +8,12 @@
     padding-right: 10px; // make sure there is overlap between anchor and heading
     position: absolute;
     text-decoration: none;
+
+    &:focus-visible {
+        #{ $self }__icon {
+            visibility: visible;
+        }
+    }
 
     &__icon {
         display: inline-block;

--- a/hugo/assets/scss/components/article.scss
+++ b/hugo/assets/scss/components/article.scss
@@ -56,7 +56,6 @@
     h4,
     h5,
     h6 {
-        &:focus,
         &:hover {
             .anchor__icon {
                 visibility: visible;


### PR DESCRIPTION
- Add missing import to anchor scss file
- Make sure anchor icon also shows when using the keyboard to navigate the page
- Remove focus style on headings since headings are not focusable so this doesn't do anything

For: https://linear.app/usmedia/issue/CUE-242