### PR TITLE
Search: Add filtering

### DIFF
--- a/hugo/assets/ts/helpers/algolia.ts
+++ b/hugo/assets/ts/helpers/algolia.ts
@@ -1,0 +1,58 @@
+import { FACET_INPUTS, FilterOperator, SearchFacet, SearchFacets, SearchInputFacetName } from '../interfaces/search';
+import { cleanObject } from './cleaner';
+
+export const getFacetForInput = (inputName: SearchInputFacetName): SearchFacet => {
+    switch (inputName) {
+        case SearchInputFacetName.CATEGORY:
+            return SearchFacet.CATEGORIES;
+        case SearchInputFacetName.SECTION:
+            return SearchFacet.SECTION;
+        case SearchInputFacetName.TAG:
+            return SearchFacet.TAGS;
+        default:
+            return null;
+    }
+};
+
+export const mapToAlgoliaFilters = (tagsByFacet: SearchFacets, operator: FilterOperator = FilterOperator.AND): string => {
+    return Object.keys(tagsByFacet)
+        .map((facet) => {
+            return `(${ tagsByFacet[facet]
+                .map((label: string) => `${ facet }:"${ label }"`)
+                .join(' OR ') })`;
+        })
+        .join(` ${ operator } `);
+};
+
+export const parseQuery = (query: string): { cleanQuery: string; facets: SearchFacets; } => {
+    let cleanQuery = query;
+
+    const facets: SearchFacets = {
+        [SearchFacet.TAGS]: [],
+        [SearchFacet.CATEGORIES]: [],
+        [SearchFacet.SECTION]: [],
+    };
+
+    for (const facetInput of FACET_INPUTS) {
+        const facet = getFacetForInput(facetInput);
+        if (!facet) {
+            continue;
+        }
+
+        const regExp = new RegExp(`${ facetInput }:(\\S+)?`, 'g');
+        const matches =  [ ...query.matchAll(regExp) ];
+        for (const match of matches) {
+            if (match) {
+                if (match[1] && match[1] !== '') {
+                    facets[facet].push(match[1]);
+                }
+                cleanQuery = cleanQuery.replace(match[0], '');
+            }
+        }
+    }
+
+    return {
+        cleanQuery: cleanQuery.trim(),
+        facets: cleanObject<SearchFacets>(facets),
+    };
+};

--- a/hugo/assets/ts/helpers/cleaner.ts
+++ b/hugo/assets/ts/helpers/cleaner.ts
@@ -1,0 +1,29 @@
+/* eslint-disable @typescript-eslint/explicit-module-boundary-types */
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
+/**
+ * Returns the given object, with all 'empty' values removed (with deep checks)
+ *
+ * Considered empty
+ * - null
+ * - undefined
+ * - '' (empty string)
+ * - [] (empty array)
+ *
+ * @param data
+ */
+export const cleanObject = <T = Record<string, any>>(data: T): T => {
+    Object.keys(data).forEach(key => {
+        if (data[key] && Array.isArray(data[key])) {
+            if (data[key].length === 0) {
+                delete data[key];
+            }
+        } else if (data[key] && typeof data[key] === 'object') {
+            cleanObject(data[key]);
+        } else if (data[key] === null || data[key] === undefined || data[key] === '') {
+            delete data[key];
+        }
+    });
+
+    return data;
+};

--- a/hugo/assets/ts/interfaces/search.ts
+++ b/hugo/assets/ts/interfaces/search.ts
@@ -7,3 +7,28 @@ export interface SearchItem {
     publishDate: string;
     content: string;
 }
+
+export enum FilterOperator {
+    AND = 'AND',
+    OR = 'OR',
+}
+
+export enum SearchInputFacetName {
+    CATEGORY = 'category',
+    SECTION = 'section',
+    TAG = 'tag',
+}
+
+export const FACET_INPUTS = [
+    SearchInputFacetName.CATEGORY,
+    SearchInputFacetName.SECTION,
+    SearchInputFacetName.TAG,
+];
+
+export enum SearchFacet {
+    CATEGORIES = 'categories',
+    SECTION = 'section',
+    TAGS = 'tags',
+}
+
+export type SearchFacets = { [key in SearchFacet]?: string[] };

--- a/hugo/assets/ts/widgets/search-autocomplete.ts
+++ b/hugo/assets/ts/widgets/search-autocomplete.ts
@@ -8,6 +8,7 @@ import { AutocompleteQuerySuggestionsHit } from '@algolia/autocomplete-plugin-qu
 import { AutocompleteApi } from '@algolia/autocomplete-js/dist/esm/types';
 import { BaseItem, OnSubmitParams } from '@algolia/autocomplete-shared/dist/esm/core';
 import { BaseWidget } from './base-widget';
+import { mapToAlgoliaFilters, parseQuery } from '../helpers/algolia';
 
 export class SearchAutocomplete extends BaseWidget {
     public static readonly NAME = 'search-autocomplete';
@@ -125,15 +126,19 @@ export class SearchAutocomplete extends BaseWidget {
                         return item.title.toString();
                     },
                     getItems({ query }) {
+                        const parsedQuery = parseQuery(query);
+                        const filters = mapToAlgoliaFilters(parsedQuery.facets);
+
                         return getAlgoliaResults({
                             searchClient,
                             queries: [{
                                 indexName: 'cuelang.org',
-                                query,
+                                query: parsedQuery.cleanQuery,
                                 params: {
                                     hitsPerPage: 5,
                                     attributesToSnippet: ['title:6', 'summary:25'],
                                     snippetEllipsisText: '…',
+                                    filters: filters,
                                 },
                             }],
                         });

--- a/hugo/assets/ts/widgets/search-results.ts
+++ b/hugo/assets/ts/widgets/search-results.ts
@@ -3,6 +3,7 @@ import { Hit } from '@algolia/client-search';
 import { BaseWidget } from './base-widget';
 import { SearchItem } from '../interfaces/search';
 import { Teaser } from '../interfaces/teaser';
+import { mapToAlgoliaFilters, parseQuery } from '../helpers/algolia';
 
 export class SearchResults extends BaseWidget {
     public static readonly NAME = 'search-results';
@@ -49,10 +50,13 @@ export class SearchResults extends BaseWidget {
         }
 
         const resultsNumber = this.element.querySelector<HTMLElement>('.searchbar__results') || undefined;
+        const parsedQuery = parseQuery(query);
+        const filters = mapToAlgoliaFilters(parsedQuery.facets);
 
         this.index
-            .search<SearchItem>(query, {
+            .search<SearchItem>(parsedQuery.cleanQuery, {
                 hitsPerPage: 100,
+                filters: filters,
             })
             .then(results => {
                 const teasers = results.hits.map(hit => this.mapSearchHitToTeaser(hit));


### PR DESCRIPTION
- Make it possible to filter facets (tags, categories & sections) via input query
- Get values for tag:tag1 tag:tag2 category:language etc from query
- Parse query: get filters from query and parse them to algolia filter facets
- Remove filters from query, so we pass a clean query to algolia with search the search query and not the filters because those are handled separately
- Make sure we have a clean object: remove empty filters
- Add the filters from the query to algolia search & autocomplete search params

For: https://linear.app/usmedia/issue/CUE-237

-----------

Tags & sections will start working after https://github.com/cue-lang/cuelang.org/pull/366  gets merged and tags get added to the front matter.

Example to illustrate the idea:  https://deploy-preview-368--cue.netlify.app/search/?q=some%20term%20%20tag:cue%20category:language%20tag:bla2%20section:docs
which results in the query: ```{"query":"some term","hitsPerPage":100,"filters":"(tags:\"cue\" OR tags:\"bla2\") AND (categories:\"language\") AND (section:\"docs\")"}```


Example with a category we have: https://deploy-preview-368--cue.netlify.app/search/?q=category:Language
