### PR TITLE
doc: replace ioutil references in Go/protobuf integration docs

### DIFF
--- a/content/en/docs/integrations/go.md
+++ b/content/en/docs/integrations/go.md
@@ -223,5 +223,5 @@ if err != nil {
     // handle error
 }
 
-err = ioutil.WriteFile("cue_gen.go", b, 0644)
+err = os.WriteFile("cue_gen.go", b, 0644)
 ```

--- a/content/en/docs/integrations/protobuf.md
+++ b/content/en/docs/integrations/protobuf.md
@@ -127,7 +127,7 @@ func main() {
 	}
 
 	b, _ := format.Node(file)
-	ioutil.WriteFile("out.cue", b, 0644)
+	os.WriteFile("out.cue", b, 0644)
 }
 {{< /highlight  >}}
 


### PR DESCRIPTION
Hi!

I was going through the tutorials / documentation to learn about cue and noticed the docs were using the deprecated ioutil package. This is a small update to use the `os` package's function instead. 