### PR TITLE
Search: Improve searchable attributes

### DIFF
--- a/content/docs/howto/best-practices/en.md
+++ b/content/docs/howto/best-practices/en.md
@@ -2,6 +2,6 @@
 title: Best practices
 weight: 50
 draft: false
-layout: category-overview
-category: Best practices
+layout: tag-overview
+tag: Best practices
 ---

--- a/content/docs/howto/cue-command/en.md
+++ b/content/docs/howto/cue-command/en.md
@@ -2,6 +2,6 @@
 title: cue command
 weight: 40
 draft: false
-layout: category-overview
-category: cue command
+layout: tag-overview
+tag: cue command
 ---

--- a/content/docs/howto/ecosystem/en.md
+++ b/content/docs/howto/ecosystem/en.md
@@ -2,6 +2,6 @@
 title: Ecosystem
 weight: 60
 draft: false
-layout: category-overview
-category: Ecosystem
+layout: tag-overview
+tag: Ecosystem
 ---

--- a/content/docs/howto/encode-json-yaml-with-cue/en.md
+++ b/content/docs/howto/encode-json-yaml-with-cue/en.md
@@ -2,7 +2,7 @@
 title: Encode JSON or YAML with CUE
 weight:
 draft: false
-categories:
+tags:
     - Use encodings in CUE
 ---
 ## Introduction

--- a/content/docs/howto/ensure-min-max-list/en.md
+++ b/content/docs/howto/ensure-min-max-list/en.md
@@ -2,7 +2,7 @@
 title: Require min or max items in a list
 weight:
 draft: false
-categories:
+tags:
     - Language
 ---
 

--- a/content/docs/howto/go-api/en.md
+++ b/content/docs/howto/go-api/en.md
@@ -2,6 +2,6 @@
 title: Go API
 weight: 30
 draft: false
-layout: category-overview
-category: Go API
+layout: tag-overview
+tag: Go API
 ---

--- a/content/docs/howto/language/en.md
+++ b/content/docs/howto/language/en.md
@@ -2,6 +2,6 @@
 title: Language
 weight: 10
 draft: false
-layout: category-overview
-category: Language
+layout: tag-overview
+tag: Language
 ---

--- a/content/docs/howto/list-no-duplicates/en.md
+++ b/content/docs/howto/list-no-duplicates/en.md
@@ -2,7 +2,7 @@
 title: Ensure lists have no duplicate items
 weight:
 draft: false
-categories:
+tags:
     - Language
 ---
 

--- a/content/docs/howto/use-cue-with-github-actions/en.md
+++ b/content/docs/howto/use-cue-with-github-actions/en.md
@@ -2,6 +2,6 @@
 title: How to use CUE with GitHub Actions
 weight:
 draft: false
-categories:
+tags:
     - Ecosystem
 ---

--- a/content/docs/howto/use-encodings-in-cue/en.md
+++ b/content/docs/howto/use-encodings-in-cue/en.md
@@ -2,6 +2,6 @@
 title: Use encodings in CUE
 weight: 20
 draft: false
-layout: category-overview
-category: Use encodings in CUE
+layout: tag-overview
+tag: Use encodings in CUE
 ---

--- a/content/docs/howto/use-the-preprocessor/en.md
+++ b/content/docs/howto/use-the-preprocessor/en.md
@@ -2,6 +2,6 @@
 title: How to use the preprocessor
 weight:
 draft: false
-categories:
+tags:
     - Ecosystem
 ---

--- a/content/docs/howto/validate-yaml-using-cue/en.md
+++ b/content/docs/howto/validate-yaml-using-cue/en.md
@@ -2,7 +2,7 @@
 title: How to validate YAML using CUE
 weight:
 draft: false
-categories:
+tags:
     - cue command
 ---
 

--- a/hugo/algolia-settings.js
+++ b/hugo/algolia-settings.js
@@ -20,8 +20,8 @@ const index = client.initIndex(indexName);
 
 index.setSettings({
     queryLanguages: ['en'],
-    searchableAttributes: ['title', 'content', 'summary', 'categories', 'tags', 'section'],
-    attributesForFaceting: ['categories', 'tags', 'section'],
+    searchableAttributes: ['title', 'content', 'summary', 'tags', 'contentType'],
+    attributesForFaceting: ['tags', 'contentType'],
     distinct: true,
     attributeForDistinct: 'link',
     highlightPreTag: '<mark>',

--- a/hugo/assets/ts/helpers/algolia.ts
+++ b/hugo/assets/ts/helpers/algolia.ts
@@ -3,10 +3,8 @@ import { cleanObject } from './cleaner';
 
 export const getFacetForInput = (inputName: SearchInputFacetName): SearchFacet => {
     switch (inputName) {
-        case SearchInputFacetName.CATEGORY:
-            return SearchFacet.CATEGORIES;
-        case SearchInputFacetName.SECTION:
-            return SearchFacet.SECTION;
+        case SearchInputFacetName.CONTENT_TYPE:
+            return SearchFacet.CONTENT_TYPE;
         case SearchInputFacetName.TAG:
             return SearchFacet.TAGS;
         default:
@@ -29,8 +27,7 @@ export const parseQuery = (query: string): { cleanQuery: string; facets: SearchF
 
     const facets: SearchFacets = {
         [SearchFacet.TAGS]: [],
-        [SearchFacet.CATEGORIES]: [],
-        [SearchFacet.SECTION]: [],
+        [SearchFacet.CONTENT_TYPE]: [],
     };
 
     for (const facetInput of FACET_INPUTS) {
@@ -40,7 +37,7 @@ export const parseQuery = (query: string): { cleanQuery: string; facets: SearchF
         }
 
         const regExp = new RegExp(`${ facetInput }:(\\S+)?`, 'g');
-        const matches =  [ ...query.matchAll(regExp) ];
+        const matches = [ ...query.matchAll(regExp) ];
         for (const match of matches) {
             if (match) {
                 if (match[1] && match[1] !== '') {

--- a/hugo/assets/ts/interfaces/search.ts
+++ b/hugo/assets/ts/interfaces/search.ts
@@ -5,8 +5,7 @@ export interface SearchItem {
     summary: string;
     publishDate: string;
     content: string;
-    section: string;
-    categories: string | string[];
+    contentType: string;
     tags: string | string[];
 }
 
@@ -16,20 +15,17 @@ export enum FilterOperator {
 }
 
 export enum SearchInputFacetName {
-    CATEGORY = 'category',
-    SECTION = 'section',
+    CONTENT_TYPE = 'contentType',
     TAG = 'tag',
 }
 
 export const FACET_INPUTS = [
-    SearchInputFacetName.CATEGORY,
-    SearchInputFacetName.SECTION,
+    SearchInputFacetName.CONTENT_TYPE,
     SearchInputFacetName.TAG,
 ];
 
 export enum SearchFacet {
-    CATEGORIES = 'categories',
-    SECTION = 'section',
+    CONTENT_TYPE = 'contentType',
     TAGS = 'tags',
 }
 

--- a/hugo/assets/ts/interfaces/teaser.ts
+++ b/hugo/assets/ts/interfaces/teaser.ts
@@ -2,5 +2,6 @@ export interface Teaser {
     title: string;
     link: string;
     summary: string;
-    categories: string | string[];
+    contentType: string;
+    tags: string | string[];
 }

--- a/hugo/assets/ts/widgets/search-results.ts
+++ b/hugo/assets/ts/widgets/search-results.ts
@@ -79,7 +79,8 @@ export class SearchResults extends BaseWidget {
             title: hit._highlightResult.title.value,
             link: hit.link,
             summary: hit._snippetResult.summary.value,
-            categories: hit.categories,
+            contentType: hit.contentType,
+            tags: hit.tags,
         };
     }
 
@@ -87,16 +88,8 @@ export class SearchResults extends BaseWidget {
         return `
             <div class="teaser teaser--search">
                 <h2 class="teaser__title">${ teaser.title }</h2>
-                ${ (teaser.categories && teaser.categories.length > 0) ?
-                    `<div class="teaser__meta">${ typeof teaser.categories === 'string'
-                        ? teaser.categories
-                        : teaser.categories.join(', ') }</div>` :
-                    ''
-                }
-                ${ (teaser.summary) ?
-                    `<div class="teaser__excerpt">${ teaser.summary }</div>` :
-                    ''
-                }
+                ${ (teaser.contentType) ? `<p class="teaser__meta">${ teaser.contentType}</p>` : '' }
+                ${ (teaser.summary) ? `<div class="teaser__excerpt">${ teaser.summary }</div>` : '' }
                 <a class="teaser__link" href="${ teaser.link }">
                     <span>Read more</span>
                 </a>

--- a/hugo/content/en/docs/howto/best-practices/index.md
+++ b/hugo/content/en/docs/howto/best-practices/index.md
@@ -2,6 +2,6 @@
 title: Best practices
 weight: 50
 draft: false
-layout: category-overview
-category: Best practices
+layout: tag-overview
+tag: Best practices
 ---

--- a/hugo/content/en/docs/howto/cue-command/index.md
+++ b/hugo/content/en/docs/howto/cue-command/index.md
@@ -2,6 +2,6 @@
 title: cue command
 weight: 40
 draft: false
-layout: category-overview
-category: cue command
+layout: tag-overview
+tag: cue command
 ---

--- a/hugo/content/en/docs/howto/ecosystem/index.md
+++ b/hugo/content/en/docs/howto/ecosystem/index.md
@@ -2,6 +2,6 @@
 title: Ecosystem
 weight: 60
 draft: false
-layout: category-overview
-category: Ecosystem
+layout: tag-overview
+tag: Ecosystem
 ---

--- a/hugo/content/en/docs/howto/encode-json-yaml-with-cue/index.md
+++ b/hugo/content/en/docs/howto/encode-json-yaml-with-cue/index.md
@@ -2,7 +2,7 @@
 title: Encode JSON or YAML with CUE
 weight:
 draft: false
-categories:
+tags:
     - Use encodings in CUE
 ---
 ## Introduction

--- a/hugo/content/en/docs/howto/ensure-min-max-list/index.md
+++ b/hugo/content/en/docs/howto/ensure-min-max-list/index.md
@@ -2,7 +2,7 @@
 title: Require min or max items in a list
 weight:
 draft: false
-categories:
+tags:
     - Language
 ---
 

--- a/hugo/content/en/docs/howto/go-api/index.md
+++ b/hugo/content/en/docs/howto/go-api/index.md
@@ -2,6 +2,6 @@
 title: Go API
 weight: 30
 draft: false
-layout: category-overview
-category: Go API
+layout: tag-overview
+tag: Go API
 ---

--- a/hugo/content/en/docs/howto/language/index.md
+++ b/hugo/content/en/docs/howto/language/index.md
@@ -2,6 +2,6 @@
 title: Language
 weight: 10
 draft: false
-layout: category-overview
-category: Language
+layout: tag-overview
+tag: Language
 ---

--- a/hugo/content/en/docs/howto/list-no-duplicates/index.md
+++ b/hugo/content/en/docs/howto/list-no-duplicates/index.md
@@ -2,7 +2,7 @@
 title: Ensure lists have no duplicate items
 weight:
 draft: false
-categories:
+tags:
     - Language
 ---
 

--- a/hugo/content/en/docs/howto/use-cue-with-github-actions/index.md
+++ b/hugo/content/en/docs/howto/use-cue-with-github-actions/index.md
@@ -2,6 +2,6 @@
 title: How to use CUE with GitHub Actions
 weight:
 draft: false
-categories:
+tags:
     - Ecosystem
 ---

--- a/hugo/content/en/docs/howto/use-encodings-in-cue/index.md
+++ b/hugo/content/en/docs/howto/use-encodings-in-cue/index.md
@@ -2,6 +2,6 @@
 title: Use encodings in CUE
 weight: 20
 draft: false
-layout: category-overview
-category: Use encodings in CUE
+layout: tag-overview
+tag: Use encodings in CUE
 ---

--- a/hugo/content/en/docs/howto/use-the-preprocessor/index.md
+++ b/hugo/content/en/docs/howto/use-the-preprocessor/index.md
@@ -2,6 +2,6 @@
 title: How to use the preprocessor
 weight:
 draft: false
-categories:
+tags:
     - Ecosystem
 ---

--- a/hugo/content/en/docs/howto/validate-yaml-using-cue/index.md
+++ b/hugo/content/en/docs/howto/validate-yaml-using-cue/index.md
@@ -2,7 +2,7 @@
 title: How to validate YAML using CUE
 weight:
 draft: false
-categories:
+tags:
     - cue command
 ---
 

--- a/hugo/layouts/_default/list.algolia.json
+++ b/hugo/layouts/_default/list.algolia.json
@@ -8,7 +8,6 @@
             {{- template "algolia-object" (dict
                 "index" 0
                 "page" $page
-                "section" $section
             ) -}}
         {{- end -}}
     {{- end }}
@@ -26,9 +25,25 @@
     {{- $publishDate := $page.PublishDate -}}
     {{- $summary := $page.Summary -}}
     {{- $content := "" -}}
-    {{- $section := $page.Section -}}
-    {{- $categories := cond (isset $page.Params "categories") ($page.Params.categories) "" -}}
     {{- $tags := cond (isset $page.Params "tags") ($page.Params.tags) "" -}}
+    {{- $contentType := $page.FirstSection.Title -}}
+
+    {{/* If section is docs we derive the content type from the first level of nesting within docs*/}}
+    {{- if and (eq $page.Section "docs") (ne $page $page.FirstSection) -}}
+        {{ $parent := $page.Parent -}}
+
+        {{/* Go up tree to find first level parent which is not /docs itself */}}
+        {{- if and $parent (ne $parent $page.FirstSection) -}}
+            {{ $contentType = $parent.Title }}
+            {{ $parent = $parent.Parent -}}
+            {{- if and $parent (ne $parent $page.FirstSection) -}}
+                {{ $contentType = $parent.Title }}
+            {{- end -}}
+        {{- else -}}
+            {{/* If no parent we're already at top level so current page is the content type */}}
+            {{ $contentType = $page.Title }}
+        {{- end -}}
+    {{- end -}}
 
     {{- if eq $index 0 -}}
         {{- $content = delimit (first $cutoff $page.PlainWords) " " -}}
@@ -43,8 +58,7 @@
         "publishDate": {{ $publishDate | jsonify }},
         "summary": {{ $summary | jsonify }},
         "content": {{ $content  | jsonify}},
-        "section": {{ $section | jsonify }},
-        "categories": {{ $categories | jsonify }},
+        "contentType": {{ $contentType | jsonify }},
         "tags": {{ $tags | jsonify }}
     }
 

--- a/hugo/layouts/docs/tag-overview.html
+++ b/hugo/layouts/docs/tag-overview.html
@@ -13,7 +13,7 @@
                     <div class="article__content">
                         {{ .Content }}
 
-                        {{ partial "paging/category-index.html" . }}
+                        {{ partial "paging/tag-index.html" . }}
                     </div>
 
                     {{ partial "separator.html" }}

--- a/hugo/layouts/partials/paging/tag-index.html
+++ b/hugo/layouts/partials/paging/tag-index.html
@@ -1,13 +1,13 @@
 {{ $current := . -}}
 {{ $parent := .Parent -}}
-{{ $category := $current.Params.category -}}
+{{ $tag := $current.Params.tag -}}
 
 {{ $pages := (where .Site.Pages "Section" .Section).ByWeight -}}
 {{ $pages = (where $pages "Type" "!=" "search") -}}
 {{ $pages = (where $pages ".Params.hide_summary" "!=" true) -}}
 {{ $pages = (where $pages ".Parent" "!=" nil) -}}
 {{ $pages = (where $pages "Parent.File.UniqueID" "==" $parent.File.UniqueID) -}}
-{{ $pages = (where $pages ".Params.categories" "intersect" (slice $category) ) -}}
+{{ $pages = (where $pages ".Params.tags" "intersect" (slice $tag) ) -}}
 
 {{ if not (eq (len $pages) 0) -}}
     <nav class="nav nav--index">

--- a/hugo/layouts/partials/paging/tree.html
+++ b/hugo/layouts/partials/paging/tree.html
@@ -52,15 +52,15 @@
     {{ $isActiveChapter := .isActiveChapter -}}
     {{ $isActive := (eq $s $p) -}}
     {{ $isActivePath := ($p.IsDescendant $s) -}}
-    {{ $isCategoryOverview := eq $s.Params.layout "category-overview" -}}
+    {{ $isTagOverview := eq $s.Params.layout "tag-overview" -}}
 
     {{ $pages := where (union $s.Pages $s.Sections).ByWeight ".Params.toc_hide" "!=" true -}}
 
-    {{ if $isCategoryOverview }}
-        {{ $category := $s.Params.category -}}
-        {{ $isActivePath = and $isActiveChapter (in $p.Params.categories $category) -}}
+    {{ if $isTagOverview }}
+        {{ $tag := $s.Params.tag -}}
+        {{ $isActivePath = and $isActiveChapter (in $p.Params.tags $tag) -}}
         {{ $pages = where (union $s.Parent.Pages $s.Parent.Sections).ByWeight ".Params.toc_hide" "!=" true -}}
-        {{ $pages = (where $pages ".Params.categories" "intersect" (slice $category) ) -}}
+        {{ $pages = (where $pages ".Params.tags" "intersect" (slice $tag) ) -}}
     {{- end }}
 
     {{- $isPage := gt (add $depth 1) 2 }}
@@ -79,9 +79,9 @@
             {{- $depth := add $depth 1 }}
             <ul class="tree__list {{ if gt $depth 2 }}is-page{{ else }}is-chapter{{ end }}">
                 {{ range $pages -}}
-                    {{- $chapterWithCategory := and (eq $depth 2) (isset .Params "categories") }}
+                    {{- $chapterWithTag := and (eq $depth 2) (isset .Params "tags") }}
                     {{- $isRoot := (and (eq $s $p.Site.Home) (eq .Params.toc_root true)) }}
-                    {{ if and (not $isRoot) (not $chapterWithCategory) -}}
+                    {{ if and (not $isRoot) (not $chapterWithTag) -}}
                         {{ template "tree-nav-section" (dict
                             "page" $p
                             "section" .


### PR DESCRIPTION
- Remove category from search-filters
- Replace categories with tags in docs pages
- Rename category-overview and category-index to tags-overviews and tags-index
- Rename section to contentType
- Show contentType instead of categories in search-teaser.
- On pages of type 'docs' use the top level parent page as content type (language-guide, how-to etc)

For: https://linear.app/usmedia/issue/CUE-250

----
Testing: 
Searching itself for contentType can only be tested after merge because the algolia index gets updated when merging to alpha.
The json which will get uploaded to algolia you can see at: https://deploy-preview-372--cue.netlify.app/algolia.json