### PR TITLE
Hugo: add the meta description tag to the head of the html

### DIFF
--- a/hugo/layouts/partials/site/head.html
+++ b/hugo/layouts/partials/site/head.html
@@ -1,5 +1,9 @@
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
+<meta name="description" content="{{ with .Description | $.RenderString | plainify }}{{ . -}}
+{{ else }}{{ with .Summary }}{{ replace ( trim ( . | plainify | htmlUnescape | chomp | truncate 160) " ")  "\n" "" -}}
+{{ else }}{{ with .Site.Params.description -}}{{- . | $.RenderString | plainify -}}
+{{ end }}{{ end }}{{ end -}}">
 {{ hugo.Generator }}
 {{ if eq (getenv "HUGO_ENV") "production" }}
 <meta name="robots" content="index, follow">


### PR DESCRIPTION
This will add the meta tag with name="description" to the head of the html.

- the value of the tag will be set to the page's params description;

- with a fallback to the, by Hugo generated, summary of the page; and

- with a fallback to the general description of the Site Params;

For https://linear.app/usmedia/issue/CUE-252