### PR TITLE
Hugo: Build script improvements

### DIFF
--- a/_scripts/build.bash
+++ b/_scripts/build.bash
@@ -10,10 +10,12 @@ cd "$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )/.."
 skipcache=""
 norun="true"
 time=""
+minify="--minify"
 if [ "${NETLIFY:-}" != "true" ]
 then
 	time="time -p"
 	norun="false"
+	minify=""
 	if [ "${CI:-}" == "true" ]
 	then
 		skipcache="--skipcache=true"
@@ -29,5 +31,4 @@ bash _scripts/runPreprocessor.bash execute --debug=all --norun=$norun $skipcache
 # Main site
 cd hugo
 $time npm ci
-$time npm run icons
-$time hugo --cleanDestinationDir $@
+$time hugo --cleanDestinationDir $minify $@


### PR DESCRIPTION
- Add minify flag to hugo build in order to have minified html output which results in a better speed performance.
- Remove npm run icons task from the build script since it's not needed because the icon sprites itself are in the asset folder in the src. This script only needs to run manually when an icon is added (see hugo/readme.md). Running this in the pipeline can even cause git issues because this way the build script might update the sprite asset in the src folder which causes a git diff.

For: https://linear.app/usmedia/issue/CUE-253