### PR TITLE
hugo: blog template

### DIFF
--- a/content/blog/example/en.md
+++ b/content/blog/example/en.md
@@ -1,0 +1,21 @@
+---
+title: Example blog page
+date: "2023-04-06"
+draft: false
+---
+
+Pellentesque habitant morbi tristique senectus et netus et malesuada fames ac turpis egestas. Vestibulum tortor quam, feugiat vitae, ultricies eget, tempor sit amet, ante. Donec eu libero sit amet quam egestas semper. Aenean ultricies mi vitae est. Mauris placerat eleifend leo.
+
+{{< figure src="/img/social.png" title="A test image" align="wide" >}}
+
+Pellentesque habitant morbi tristique senectus et netus et malesuada fames ac turpis egestas. Vestibulum tortor quam, feugiat vitae, ultricies eget, tempor sit amet, ante. Donec eu libero sit amet quam egestas semper. Aenean ultricies mi vitae est. Mauris placerat eleifend leo. Quisque sit amet est et sapien ullamcorper pharetra. Vestibulum erat wisi, condimentum sed, commodo vitae, ornare sit amet, wisi. Aenean fermentum, elit eget tincidunt condimentum, eros ipsum rutrum orci, sagittis tempus lacus enim ac dui. Donec non enim in turpis pulvinar facilisis. Ut felis. Praesent dapibus, neque id cursus faucibus, tortor neque egestas augue, eu vulputate magna eros eu erat. Aliquam erat volutpat. Nam dui mi, tincidunt quis, accumsan porttitor, facilisis luctus, metus.
+
+{{< figure src="/img/social.png" title="A test image" >}}
+
+### Configuration complexity
+
+Pellentesque habitant morbi tristique senectus et netus et malesuada fames ac turpis egestas. Vestibulum tortor quam, feugiat vitae, ultricies eget, tempor sit amet, ante. Donec eu libero sit amet quam egestas semper. Aenean ultricies mi vitae est. Mauris placerat eleifend leo. Quisque sit amet est et sapien ullamcorper pharetra. Vestibulum erat wisi, condimentum sed, commodo vitae, ornare sit amet, wisi. Aenean fermentum, elit eget tincidunt condimentum, eros ipsum rutrum orci, sagittis tempus lacus enim ac dui. Donec non enim in turpis pulvinar facilisis. Ut felis. Praesent dapibus, neque id cursus faucibus, tortor neque egestas augue, eu vulputate magna eros eu erat. Aliquam erat volutpat. Nam dui mi, tincidunt quis, accumsan porttitor, facilisis luctus, metus.
+
+[Official CUE releases](https://github.com/cue-lang/cue/releases/)
+
+Pellentesque habitant morbi tristique senectus et netus et malesuada fames ac turpis egestas. Vestibulum tortor quam, feugiat vitae, ultricies eget, tempor sit amet, ante. Donec eu libero sit amet quam egestas semper. Aenean ultricies mi vitae est. Mauris placerat eleifend leo. Quisque sit amet est et sapien ullamcorper pharetra. Vestibulum erat wisi, condimentum sed, commodo vitae, ornare sit amet, wisi.

--- a/content/blog/example/page.cue
+++ b/content/blog/example/page.cue
@@ -1,0 +1,3 @@
+package site
+
+"blog": "example": {}

--- a/content/blog/example2/en.md
+++ b/content/blog/example2/en.md
@@ -1,0 +1,21 @@
+---
+title: Example blog page 2
+date: "2023-03-10"
+draft: false
+---
+
+Pellentesque habitant morbi tristique senectus et netus et malesuada fames ac turpis egestas. Vestibulum tortor quam, feugiat vitae, ultricies eget, tempor sit amet, ante. Donec eu libero sit amet quam egestas semper. Aenean ultricies mi vitae est. Mauris placerat eleifend leo.
+
+{{< figure src="/img/social.png" title="A test image" align="wide" >}}
+
+Pellentesque habitant morbi tristique senectus et netus et malesuada fames ac turpis egestas. Vestibulum tortor quam, feugiat vitae, ultricies eget, tempor sit amet, ante. Donec eu libero sit amet quam egestas semper. Aenean ultricies mi vitae est. Mauris placerat eleifend leo. Quisque sit amet est et sapien ullamcorper pharetra. Vestibulum erat wisi, condimentum sed, commodo vitae, ornare sit amet, wisi. Aenean fermentum, elit eget tincidunt condimentum, eros ipsum rutrum orci, sagittis tempus lacus enim ac dui. Donec non enim in turpis pulvinar facilisis. Ut felis. Praesent dapibus, neque id cursus faucibus, tortor neque egestas augue, eu vulputate magna eros eu erat. Aliquam erat volutpat. Nam dui mi, tincidunt quis, accumsan porttitor, facilisis luctus, metus.
+
+{{< figure src="/img/social.png" title="A test image" >}}
+
+### Configuration complexity
+
+Pellentesque habitant morbi tristique senectus et netus et malesuada fames ac turpis egestas. Vestibulum tortor quam, feugiat vitae, ultricies eget, tempor sit amet, ante. Donec eu libero sit amet quam egestas semper. Aenean ultricies mi vitae est. Mauris placerat eleifend leo. Quisque sit amet est et sapien ullamcorper pharetra. Vestibulum erat wisi, condimentum sed, commodo vitae, ornare sit amet, wisi. Aenean fermentum, elit eget tincidunt condimentum, eros ipsum rutrum orci, sagittis tempus lacus enim ac dui. Donec non enim in turpis pulvinar facilisis. Ut felis. Praesent dapibus, neque id cursus faucibus, tortor neque egestas augue, eu vulputate magna eros eu erat. Aliquam erat volutpat. Nam dui mi, tincidunt quis, accumsan porttitor, facilisis luctus, metus.
+
+[Official CUE releases](https://github.com/cue-lang/cue/releases/)
+
+Pellentesque habitant morbi tristique senectus et netus et malesuada fames ac turpis egestas. Vestibulum tortor quam, feugiat vitae, ultricies eget, tempor sit amet, ante. Donec eu libero sit amet quam egestas semper. Aenean ultricies mi vitae est. Mauris placerat eleifend leo. Quisque sit amet est et sapien ullamcorper pharetra. Vestibulum erat wisi, condimentum sed, commodo vitae, ornare sit amet, wisi. Aenean fermentum, elit eget tincidunt condimentum, eros ipsum rutrum orci, sagittis tempus lacus enim ac dui. Donec non enim in turpis pulvinar facilisis. Ut felis. Praesent dapibus, neque id cursus faucibus, tortor neque egestas augue, eu vulputate magna eros eu erat. Aliquam erat volutpat. Nam dui mi, tincidunt quis, accumsan porttitor, facilisis luctus, metus.

--- a/content/blog/example2/page.cue
+++ b/content/blog/example2/page.cue
@@ -1,0 +1,3 @@
+package site
+
+"blog": "example2": {}

--- a/hugo/assets/scss/components/anchor.scss
+++ b/hugo/assets/scss/components/anchor.scss
@@ -4,7 +4,7 @@
 .anchor {
     $self: &;
 
-    left: 4px;
+    left: 2px;
     padding-right: 10px; // make sure there is overlap between anchor and heading
     position: absolute;
     text-decoration: none;

--- a/hugo/assets/scss/components/article.scss
+++ b/hugo/assets/scss/components/article.scss
@@ -11,12 +11,14 @@
 
     background-color: var(--article-background, $c-white);
     height: 100%;
+    margin: 0 auto;
+    max-width: $w-content--small;
     padding: 2rem 0;
 
     &__container {
         @include container($w-content);
 
-        padding: 0 1.5rem;
+        padding: 0 $p-gutter;
         position: relative;
     }
 
@@ -39,6 +41,12 @@
 
     &__content {
         padding-bottom: 2rem;
+    }
+
+    &--blog {
+        p:first-child {
+            @include style-intro-article;
+        }
     }
 
     &--docs {
@@ -66,6 +74,20 @@
     @include screen($screen-normal) {
         &__container {
             padding: 0 1.875rem;
+        }
+
+        &--blog {
+            #{ $self }__header {
+                margin: 0 (-$p-gutter--large);
+            }
+        }
+    }
+
+    @include screen($screen-large) {
+        &--blog {
+            #{ $self }__header {
+                margin: 0 (2 * -$p-gutter--large);
+            }
         }
     }
 }

--- a/hugo/assets/scss/components/separator.scss
+++ b/hugo/assets/scss/components/separator.scss
@@ -19,4 +19,11 @@
     &--wide {
         max-width: $w-section-content + 120px;
     }
+
+    &--blog {
+        background-color: $c-yellow;
+        height: 2px;
+        margin: 0 auto;
+        opacity: 1;
+    }
 }

--- a/hugo/assets/scss/config/sizes.scss
+++ b/hugo/assets/scss/config/sizes.scss
@@ -12,6 +12,7 @@ $screen-jumbo:                  1920px;
 $w-site:                        1380px;
 $w-container:                   $w-site;
 $w-content:                     940px;
+$w-content--small:              840px;
 $w-drawer:                      400px;
 $p-gutter:                      20px;
 $p-gutter--large:               40px;

--- a/hugo/assets/scss/mixins/typography.scss
+++ b/hugo/assets/scss/mixins/typography.scss
@@ -91,6 +91,15 @@
 
 // Special
 
+@mixin style-intro-article {
+    color: $c-blue--darker;
+    font-size: 1.125rem;
+
+    @include screen($screen-simple) {
+        font-size: 1.25rem;
+    }
+}
+
 @mixin style-heading-article {
     font-size: 2.75rem;
 

--- a/hugo/content/en/blog/example/index.md
+++ b/hugo/content/en/blog/example/index.md
@@ -1,0 +1,21 @@
+---
+title: Example blog page
+date: "2023-04-06"
+draft: false
+---
+
+Pellentesque habitant morbi tristique senectus et netus et malesuada fames ac turpis egestas. Vestibulum tortor quam, feugiat vitae, ultricies eget, tempor sit amet, ante. Donec eu libero sit amet quam egestas semper. Aenean ultricies mi vitae est. Mauris placerat eleifend leo.
+
+{{< figure src="/img/social.png" title="A test image" align="wide" >}}
+
+Pellentesque habitant morbi tristique senectus et netus et malesuada fames ac turpis egestas. Vestibulum tortor quam, feugiat vitae, ultricies eget, tempor sit amet, ante. Donec eu libero sit amet quam egestas semper. Aenean ultricies mi vitae est. Mauris placerat eleifend leo. Quisque sit amet est et sapien ullamcorper pharetra. Vestibulum erat wisi, condimentum sed, commodo vitae, ornare sit amet, wisi. Aenean fermentum, elit eget tincidunt condimentum, eros ipsum rutrum orci, sagittis tempus lacus enim ac dui. Donec non enim in turpis pulvinar facilisis. Ut felis. Praesent dapibus, neque id cursus faucibus, tortor neque egestas augue, eu vulputate magna eros eu erat. Aliquam erat volutpat. Nam dui mi, tincidunt quis, accumsan porttitor, facilisis luctus, metus.
+
+{{< figure src="/img/social.png" title="A test image" >}}
+
+### Configuration complexity
+
+Pellentesque habitant morbi tristique senectus et netus et malesuada fames ac turpis egestas. Vestibulum tortor quam, feugiat vitae, ultricies eget, tempor sit amet, ante. Donec eu libero sit amet quam egestas semper. Aenean ultricies mi vitae est. Mauris placerat eleifend leo. Quisque sit amet est et sapien ullamcorper pharetra. Vestibulum erat wisi, condimentum sed, commodo vitae, ornare sit amet, wisi. Aenean fermentum, elit eget tincidunt condimentum, eros ipsum rutrum orci, sagittis tempus lacus enim ac dui. Donec non enim in turpis pulvinar facilisis. Ut felis. Praesent dapibus, neque id cursus faucibus, tortor neque egestas augue, eu vulputate magna eros eu erat. Aliquam erat volutpat. Nam dui mi, tincidunt quis, accumsan porttitor, facilisis luctus, metus.
+
+[Official CUE releases](https://github.com/cue-lang/cue/releases/)
+
+Pellentesque habitant morbi tristique senectus et netus et malesuada fames ac turpis egestas. Vestibulum tortor quam, feugiat vitae, ultricies eget, tempor sit amet, ante. Donec eu libero sit amet quam egestas semper. Aenean ultricies mi vitae est. Mauris placerat eleifend leo. Quisque sit amet est et sapien ullamcorper pharetra. Vestibulum erat wisi, condimentum sed, commodo vitae, ornare sit amet, wisi.

--- a/hugo/content/en/blog/example2/index.md
+++ b/hugo/content/en/blog/example2/index.md
@@ -1,0 +1,21 @@
+---
+title: Example blog page 2
+date: "2023-03-10"
+draft: false
+---
+
+Pellentesque habitant morbi tristique senectus et netus et malesuada fames ac turpis egestas. Vestibulum tortor quam, feugiat vitae, ultricies eget, tempor sit amet, ante. Donec eu libero sit amet quam egestas semper. Aenean ultricies mi vitae est. Mauris placerat eleifend leo.
+
+{{< figure src="/img/social.png" title="A test image" align="wide" >}}
+
+Pellentesque habitant morbi tristique senectus et netus et malesuada fames ac turpis egestas. Vestibulum tortor quam, feugiat vitae, ultricies eget, tempor sit amet, ante. Donec eu libero sit amet quam egestas semper. Aenean ultricies mi vitae est. Mauris placerat eleifend leo. Quisque sit amet est et sapien ullamcorper pharetra. Vestibulum erat wisi, condimentum sed, commodo vitae, ornare sit amet, wisi. Aenean fermentum, elit eget tincidunt condimentum, eros ipsum rutrum orci, sagittis tempus lacus enim ac dui. Donec non enim in turpis pulvinar facilisis. Ut felis. Praesent dapibus, neque id cursus faucibus, tortor neque egestas augue, eu vulputate magna eros eu erat. Aliquam erat volutpat. Nam dui mi, tincidunt quis, accumsan porttitor, facilisis luctus, metus.
+
+{{< figure src="/img/social.png" title="A test image" >}}
+
+### Configuration complexity
+
+Pellentesque habitant morbi tristique senectus et netus et malesuada fames ac turpis egestas. Vestibulum tortor quam, feugiat vitae, ultricies eget, tempor sit amet, ante. Donec eu libero sit amet quam egestas semper. Aenean ultricies mi vitae est. Mauris placerat eleifend leo. Quisque sit amet est et sapien ullamcorper pharetra. Vestibulum erat wisi, condimentum sed, commodo vitae, ornare sit amet, wisi. Aenean fermentum, elit eget tincidunt condimentum, eros ipsum rutrum orci, sagittis tempus lacus enim ac dui. Donec non enim in turpis pulvinar facilisis. Ut felis. Praesent dapibus, neque id cursus faucibus, tortor neque egestas augue, eu vulputate magna eros eu erat. Aliquam erat volutpat. Nam dui mi, tincidunt quis, accumsan porttitor, facilisis luctus, metus.
+
+[Official CUE releases](https://github.com/cue-lang/cue/releases/)
+
+Pellentesque habitant morbi tristique senectus et netus et malesuada fames ac turpis egestas. Vestibulum tortor quam, feugiat vitae, ultricies eget, tempor sit amet, ante. Donec eu libero sit amet quam egestas semper. Aenean ultricies mi vitae est. Mauris placerat eleifend leo. Quisque sit amet est et sapien ullamcorper pharetra. Vestibulum erat wisi, condimentum sed, commodo vitae, ornare sit amet, wisi. Aenean fermentum, elit eget tincidunt condimentum, eros ipsum rutrum orci, sagittis tempus lacus enim ac dui. Donec non enim in turpis pulvinar facilisis. Ut felis. Praesent dapibus, neque id cursus faucibus, tortor neque egestas augue, eu vulputate magna eros eu erat. Aliquam erat volutpat. Nam dui mi, tincidunt quis, accumsan porttitor, facilisis luctus, metus.

--- a/hugo/layouts/blog/single.html
+++ b/hugo/layouts/blog/single.html
@@ -1,20 +1,29 @@
 {{ define "main" }}
     {{ partial "paging/back-button.html" . }}
 
-    <article class="article">
+    <article class="article article--blog">
         <div class="article__container">
             <header class="article__header">
                 <h1 class="article__title">{{ .Title }}</h1>
-                {{- $meta := .Params.meta -}}
-                {{- $meta = append $meta (slice (dict "type" "date" "value" (.Date.Format ($.Param "time_format")))) -}}
-                <div class="article__meta">{{ partial "meta" $meta }}</div>
+                {{ if or .Params.meta .Date }}
+                    {{ $meta := slice }}
+                    {{ if .Date }}
+                        {{ $meta = $meta | append (dict "type" "date" "value" (.Date.Format ($.Param "time_format"))) }}
+                    {{ end }}
+                    {{ if .Params.meta }}
+                        {{ $meta = $meta | append .Params.meta }}
+                    {{ end }}
+                    <div class="article__meta">{{ partial "meta" $meta }}</div>
+                {{ end }}
             </header>
             <div class="article__content">
                 {{- .Content -}}
             </div>
+            <div class="article__footer">
+                {{ partial "separator.html" (dict "modifier" "blog") }}
+            </div>
         </div>
     </article>
 
-    {{ partial "separator.html" (dict "modifier" "wide") }}
     {{ partial "paging/prev-next.html" . }}
 {{ end }}


### PR DESCRIPTION
This will add the single blog page.

- two example pages have been added: /blog/example, blog/example2;

- $p-gutter(20px) will now we be used for the padding on the horizontal sides
of articles (instead of 24px);

- the anchor, in front of headings in the articles, has a styling of left: 2px
instead of left: 4px on smaller devices, in order to be aligned now;

- a --blog modifier has been set on the article html-tag, inside the
single blog template;

- the article__footer has been added to the single blog template;

- a --blog modifier has been set on the separator, which is
to be found in the article__footer of the single blog page template;

- a scss typography mixin is created for the intro paragraph;

- if Params.meta and/or date have been set in the front-matter, the meta
partial will be rendered;

For https://linear.app/usmedia/issue/CUE-256
