### PR TITLE
hugo: detail/content page header meta

### DIFF
--- a/content/examples/basic/front-matter/en.md
+++ b/content/examples/basic/front-matter/en.md
@@ -1,6 +1,10 @@
 ---
 title: Front Matter
 weight: 14
+date: "2023-08-01"
+meta:
+    - type: readingTime
+      value: 5
 tags:
     - Use encodings in CUE
     - Language
@@ -37,18 +41,20 @@ math
 : You can add `math: true` to the front matter, if you want to enable [MathJax](https://www.mathjax.org/) on a content page.
 
 meta
-: You can show additional meta information below the title of a content page. This is map of items consisting of a type and value (and optionally a link).
+: You can show additional meta information below the title of a content page. This is a map of items consisting of a type and value.
+: If you include the type readingTime, 'min Read' will be added to the given value.
+
+: When you include a date in the front-matter, it will be automatically included in the meta information.
+
+: Available types:
+
+- readingTime (value is in minutes)
+
 ```
 meta:
-- type: link
-  value: Website
-  link: https://www.usmedia.nl
-- type: person
-  value: Joop Verkerke
-- type: other
-  value: Some info
+- type: readingTime
+  value: 5
 ```
-The type will be mapped to an icon, see `/assets/svg/ui` for a full list of possible types.
 
 notification
 : You can add a sticky notification on the current page. The `content` allows for simple markdown options.

--- a/hugo/assets/scss/components/article.scss
+++ b/hugo/assets/scss/components/article.scss
@@ -33,37 +33,26 @@
     }
 
     &__info {
+        align-items: center;
         column-gap: 1rem;
         display: flex;
         flex-wrap: wrap;
-        margin: 0.5rem 0 2rem;
-        row-gap: 0.75rem;
+        justify-content: space-between;
+        row-gap: 0.5rem;
     }
 
     &__header {
+        margin: 2.5rem 0 2rem;
         position: relative;
         width: 100%;
-
-        &--extended {
-            margin: 2.5rem 0 2rem;
-    
-            #{ $self}__title {
-                margin: 0;
-            }
-        }
     }
 
     &__title {
         @include style-heading-1;
 
         hyphens: auto;
-        margin-top: 0.75rem;
+        margin: 0 0 0.75rem;
         word-break: break-word;
-    }
-
-    &__meta {
-        color: var(--article-meta-color, $c-grey--dark);
-        margin: 0 0 0.5rem;
     }
 
     &__content {

--- a/hugo/assets/scss/components/meta.scss
+++ b/hugo/assets/scss/components/meta.scss
@@ -3,35 +3,31 @@
 .meta {
     $self: &;
 
-    color: currentColor;
-    column-gap: 2rem;
+    color: var(--meta-color, $c-grey--dark);
+    column-gap: 0.5rem;
     display: flex;
     flex-wrap: wrap;
-    row-gap: 1rem;
 
     &__item {
-        align-items: center;
-        display: flex;
-        gap: 8px;
+        position: relative;
     }
 
-    &__icon {
-        height: 1.25rem;
-        width: 1.25rem;
-    }
+    &__item + &__item {
+        margin-left: 1rem;
 
-    &__value {
-        @include style-text-small;
-    }
-
-    &__link {
-        border-bottom: 1px solid currentColor;
-        display: block;
-        text-decoration: none;
-        transition: border-bottom-color 0.2s;
-
-        &:hover {
-            border-bottom-color: transparent;
+        &::before {
+            align-items: center;
+            content: "\2022";
+            display: flex;
+            left: -1rem;
+            line-height: 1.75;
+            position: absolute;
         }
+    }
+
+    &__value, &__text {
+        @include style-text-small;
+
+        display: inline-block;
     }
 }

--- a/hugo/content/en/examples/basic/front-matter/index.md
+++ b/hugo/content/en/examples/basic/front-matter/index.md
@@ -1,6 +1,10 @@
 ---
 title: Front Matter
 weight: 14
+date: "2023-08-01"
+meta:
+    - type: readingTime
+      value: 5
 tags:
     - Use encodings in CUE
     - Language
@@ -37,18 +41,20 @@ math
 : You can add `math: true` to the front matter, if you want to enable [MathJax](https://www.mathjax.org/) on a content page.
 
 meta
-: You can show additional meta information below the title of a content page. This is map of items consisting of a type and value (and optionally a link).
+: You can show additional meta information below the title of a content page. This is a map of items consisting of a type and value.
+: If you include the type readingTime, 'min Read' will be added to the given value.
+
+: When you include a date in the front-matter, it will be automatically included in the meta information.
+
+: Available types:
+
+- readingTime (value is in minutes)
+
 ```
 meta:
-- type: link
-  value: Website
-  link: https://www.usmedia.nl
-- type: person
-  value: Joop Verkerke
-- type: other
-  value: Some info
+- type: readingTime
+  value: 5
 ```
-The type will be mapped to an icon, see `/assets/svg/ui` for a full list of possible types.
 
 notification
 : You can add a sticky notification on the current page. The `content` allows for simple markdown options.

--- a/hugo/i18n/en.toml
+++ b/hugo/i18n/en.toml
@@ -5,6 +5,8 @@ other = "Skip to content"
 other = "Homepage of CUE"
 [ui_read_more]
 other = "Read more"
+[ui_min_read]
+other = "min Read"
 [ui_loading]
 other = "Loading"
 [ui_close]

--- a/hugo/layouts/_default/single.html
+++ b/hugo/layouts/_default/single.html
@@ -10,12 +10,13 @@
     <article class="article">
         <div class="article__container">
             {{- partial "article--header" . -}}
+
             <div class="article__content">
                 {{- .Content -}}
             </div>
             <footer class="article__footer">
                 {{- if $tags -}}
-                    {{- partial "tags.html" (dict "modifier" "large" "tags" $tags ) -}} 
+                    {{- partial "tags.html" (dict "modifier" "large" "tags" $tags ) -}}
                 {{- end -}}
             </footer>
         </div>

--- a/hugo/layouts/blog/single.html
+++ b/hugo/layouts/blog/single.html
@@ -10,13 +10,14 @@
     <article class="article article--blog">
         <div class="article__container">
             {{- partial "article--header" . -}}
+
             <div class="article__content">
                 {{- .Content -}}
             </div>
-            
+
             <footer class="article__footer">
                 {{- if $tags -}}
-                    {{- partial "tags.html" (dict "modifier" "large" "tags" $tags ) -}} 
+                    {{- partial "tags.html" (dict "modifier" "large" "tags" $tags ) -}}
                 {{- end -}}
             </footer>
         </div>

--- a/hugo/layouts/docs/single.html
+++ b/hugo/layouts/docs/single.html
@@ -28,7 +28,7 @@
                     <footer class="article__footer">
                         {{ partial "last-modified.html" . }}
                         {{- if $tags -}}
-                            {{- partial "tags.html" (dict "modifier" "large" "tags" $tags ) -}} 
+                            {{- partial "tags.html" (dict "modifier" "large" "tags" $tags ) -}}
                         {{- end -}}
                     </footer>
 

--- a/hugo/layouts/partials/article--header.html
+++ b/hugo/layouts/partials/article--header.html
@@ -4,20 +4,20 @@
     {{ $tags = where $tagOptions "name" "in" .Params.tags | default slice }}
 {{- end -}}
 
-<header class="article__header{{ if or .Params.meta .Date $tags }} article__header--extended{{ end }}">
+<header class="article__header">
     <h1 class="article__title">{{ .Title }}</h1>
     {{- if or .Params.meta .Date $tags -}}
         <div class="article__info">
-            {{- $meta := slice -}}
-            {{- if .Date -}}
-                {{- $meta = $meta | append (dict "type" "date" "value" (.Date.Format ($.Param "time_format"))) -}}
-            {{- end -}}
-            {{- if .Params.meta -}}
-                {{- $meta = $meta | append .Params.meta -}}
-            {{- end -}}
-            {{- if $meta | len -}}
+            {{ if or .Params.meta .Date }}
+                {{ $meta := slice }}
+                {{ if .Date }}
+                    {{ $meta = $meta | append (dict "type" "date" "value" (.Date.Format ($.Param "time_format"))) }}
+                {{ end }}
+                {{ if .Params.meta }}
+                    {{ $meta = $meta | append .Params.meta }}
+                {{ end }}
                 <div class="article__meta">{{ partial "meta" $meta }}</div>
-            {{- end -}}
+            {{ end }}
             {{- if $tags -}}
                 <div class="article__tags">{{- partial "tags.html" (dict "tags" $tags ) -}}</div>
             {{- end -}}

--- a/hugo/layouts/partials/meta.html
+++ b/hugo/layouts/partials/meta.html
@@ -1,41 +1,17 @@
-{{/*
-    items is map with
-      - type *
-      - value
-      - link
-
-    * Possible types (for more, look in /asssets/svg/ui)
-      - office
-      - person
-      - link
-      - date
-      - time
-      - location
-      - other (== mapped to cue)
-*/}}
 {{ $items := . }}
 
 {{ if $items }}
     <ul class="meta">
-        {{ range $items }}
-            <li class="meta__item">
-                {{ if .type -}}
-                    <div class="meta__icon">
-                        {{- if eq .type "other" -}}
-                            {{- partial "icon.html" (dict "icon" "cue") -}}
-                        {{- else -}}
-                            {{- partial "icon.html" (dict "icon" .type) -}}
-                        {{- end -}}
-                    </div>
-                {{- end -}}
-                <div class="meta__value">
-                    {{- if .link -}}
-                        <a class="meta__link" href="{{ .link }}"><span>{{ .value }}</span></a>
-                    {{- else -}}
-                        <span>{{ .value }}</span>
-                    {{- end -}}
-                </div>
-            </li>
+        {{ range $index, $item := $items}}
+            {{ if and .type .value }}
+                {{ $value := .value }}
+                {{- if eq .type "readingTime" -}}
+                    {{- $value = print (T "ui_min_read") | print " " | print .value -}}
+                {{ end }}
+                 <li class="meta__item">
+                    <span class="meta__value">{{ $value }}</span>
+                </li>
+            {{ end }}
         {{ end }}
     </ul>
 {{ end }}


### PR DESCRIPTION
This will add meta details to the article header of the single pages.

- this will apply to default single pages, blog single pages and docs
single pages;

- in these single page templates the $meta variable is constructed, being
the .Date of the content, the .Params.meta of the content, a combination
of both or none. If there is meta data, then the meta partial will be
rendered;

- in the meta partial each meta item, if provided with .type and .value,
will be rendered in a list.

- if the type of the meta is readingTime, the translated text of ui_min_read
will be put after the value;

- the link-type has been removed;

- in meta.scss the bullet-separator between two meta items is applied;

- the example page of the front-matter, '/examples/front-matter', has been
updated;

- the changes are visible beneath the header on default single pages,
blog single pages and docs single pages;

For https://linear.app/usmedia/issue/CUE-262