### PR TITLE
hugo: content/detail pages - show tags on page

### DIFF
--- a/content/examples/basic/front-matter/en.md
+++ b/content/examples/basic/front-matter/en.md
@@ -1,6 +1,10 @@
 ---
 title: Front Matter
 weight: 14
+tags:
+    - Use encodings in CUE
+    - Language
+    - Ecosystem
 ---
 
 Hugo uses front-matter to add meta information to a content page. This can be done various formats - in the CUE website we prefer **YAML** (To be decided).
@@ -63,3 +67,11 @@ notification:
         icon: 'download'
 ```
 You can also add a site-wide notification via the config file for params (ex. `config/_default/params.toml`)
+
+tags
+: By adding tags in the front-matter, they will be displayed in both the header and footer of the content page. Tags link to `/search?q=tag:{name}` and initiate a search for all documents that contain the respective tag.
+```
+tags:
+- Ecosystem
+- Language
+```

--- a/hugo/assets/scss/components/article.scss
+++ b/hugo/assets/scss/components/article.scss
@@ -22,9 +22,35 @@
         position: relative;
     }
 
+    &__footer {
+        border-top: solid 2px $c-yellow;
+        display: flex;
+        flex-direction: column;
+        gap: 2rem;
+        margin: 0 auto;
+        opacity: 1;
+        padding: 1.5rem 0;
+    }
+
+    &__info {
+        column-gap: 1rem;
+        display: flex;
+        flex-wrap: wrap;
+        margin: 0.5rem 0 2rem;
+        row-gap: 0.75rem;
+    }
+
     &__header {
         position: relative;
         width: 100%;
+
+        &--extended {
+            margin: 2.5rem 0 2rem;
+    
+            #{ $self}__title {
+                margin: 0;
+            }
+        }
     }
 
     &__title {

--- a/hugo/assets/scss/components/list.scss
+++ b/hugo/assets/scss/components/list.scss
@@ -36,7 +36,7 @@
     &--tags {
         display: flex;
         flex-wrap: wrap;
-        gap: 4px;
+        gap: 7px;
     }
 
     @include screen($screen-simple) {
@@ -51,6 +51,10 @@
 
     @include screen($screen-normal) {
         gap: 2rem;
+
+        &--tags {
+            gap: 7px;
+        }
 
         &--overview {
             grid-template-columns: repeat(3, 1fr);

--- a/hugo/assets/scss/components/meta.scss
+++ b/hugo/assets/scss/components/meta.scss
@@ -7,7 +7,6 @@
     column-gap: 2rem;
     display: flex;
     flex-wrap: wrap;
-    margin: 1.5rem 0;
     row-gap: 1rem;
 
     &__item {

--- a/hugo/assets/scss/components/separator.scss
+++ b/hugo/assets/scss/components/separator.scss
@@ -19,11 +19,4 @@
     &--wide {
         max-width: $w-section-content + 120px;
     }
-
-    &--blog {
-        background-color: $c-yellow;
-        height: 2px;
-        margin: 0 auto;
-        opacity: 1;
-    }
 }

--- a/hugo/assets/scss/components/tag.scss
+++ b/hugo/assets/scss/components/tag.scss
@@ -2,15 +2,18 @@
 @import '../config/typography';
 
 .tag {
+    --tag-background: #{ $c-blue--lighter };
+
     align-items: center;
-    background: var(--tag-background, transparentize($c-white, 0.5));
-    border-radius: 24px;
+    background: var(--tag-background);
+    border-radius: 1.5rem;
+    color: $c-black;
     display: flex;
     font-size: 0.8125rem;
     font-weight: $weight-medium;
     gap: 0.5rem;
-    height: 22px;
-    line-height: 22px;
+    line-height: 1.25;
+    min-height: 1.5rem;
     padding: 0 0.6rem 0 0.5rem;
     position: relative;
     text-decoration: none;
@@ -19,7 +22,7 @@
 
     &:focus-visible,
     &:hover {
-        --tag-background: #{ $c-white };
+        --tag-background: #{ $c-lavender--light };
     }
 
     &::before {
@@ -27,8 +30,13 @@
         border-radius: 50%;
         content: '';
         display: block;
-        height: 12px;
-        width: 12px;
+        height: 0.75rem;
+        width: 0.75rem;
+    }
+
+    &--large {
+        min-height: 2.75rem;
+        padding: 0 1.25rem 0 1.125rem;
     }
 
     &--red {

--- a/hugo/assets/scss/config/colors.scss
+++ b/hugo/assets/scss/config/colors.scss
@@ -32,6 +32,8 @@ $c-filter-lila:         #9fb8de;
 $c-filter-blue:         #97d8fe;
 $c-filter-lavender:     #97b9fe;
 
+$c-lavender--light:     #DDE3FD;
+
 $c-white:               #fff;
 $c-black:               #000;
 

--- a/hugo/content/en/examples/basic/front-matter/index.md
+++ b/hugo/content/en/examples/basic/front-matter/index.md
@@ -1,6 +1,10 @@
 ---
 title: Front Matter
 weight: 14
+tags:
+    - Use encodings in CUE
+    - Language
+    - Ecosystem
 ---
 
 Hugo uses front-matter to add meta information to a content page. This can be done various formats - in the CUE website we prefer **YAML** (To be decided).
@@ -63,3 +67,11 @@ notification:
         icon: 'download'
 ```
 You can also add a site-wide notification via the config file for params (ex. `config/_default/params.toml`)
+
+tags
+: By adding tags in the front-matter, they will be displayed in both the header and footer of the content page. Tags link to `/search?q=tag:{name}` and initiate a search for all documents that contain the respective tag.
+```
+tags:
+- Ecosystem
+- Language
+```

--- a/hugo/layouts/_default/single.html
+++ b/hugo/layouts/_default/single.html
@@ -1,20 +1,25 @@
 {{ define "main" }}
+{{ $tags := slice }}
+{{- if .Params.tags -}}
+    {{ $tagOptions := .Site.Params.Tags | default slice }}
+    {{ $tags = where $tagOptions "name" "in" .Params.tags | default slice }}
+{{- end -}}
+
     {{ partial "paging/back-button.html" . }}
 
     <article class="article">
         <div class="article__container">
-            <header class="article__header">
-                <h1 class="article__title">{{ .Title }}</h1>
-                {{- with .Params.meta -}}
-                <div class="article__meta">{{ partial "meta" . }}</div>
-                {{- end }}
-            </header>
+            {{- partial "article--header" . -}}
             <div class="article__content">
                 {{- .Content -}}
             </div>
+            <footer class="article__footer">
+                {{- if $tags -}}
+                    {{- partial "tags.html" (dict "modifier" "large" "tags" $tags ) -}} 
+                {{- end -}}
+            </footer>
         </div>
     </article>
 
-    {{ partial "separator.html" (dict "modifier" "wide") }}
     {{ partial "paging/prev-next.html" . }}
 {{ end }}

--- a/hugo/layouts/blog/single.html
+++ b/hugo/layouts/blog/single.html
@@ -1,22 +1,24 @@
 {{ define "main" }}
+{{ $tags := slice }}
+{{- if .Params.tags -}}
+    {{ $tagOptions := .Site.Params.Tags | default slice }}
+    {{ $tags = where $tagOptions "name" "in" .Params.tags | default slice }}
+{{- end -}}
+
     {{ partial "paging/back-button.html" . }}
 
     <article class="article article--blog">
         <div class="article__container">
-            <header class="article__header">
-                <h1 class="article__title">{{ .Title }}</h1>
-                {{ if .Params.meta }}
-                    {{- $meta := .Params.meta -}}
-                    {{- $meta = append $meta (slice (dict "type" "date" "value" (.Date.Format ($.Param "time_format")))) -}}
-                    <div class="article__meta">{{ partial "meta" $meta }}</div>
-                {{ end }}
-            </header>
+            {{- partial "article--header" . -}}
             <div class="article__content">
                 {{- .Content -}}
             </div>
-            <div class="article__footer">
-                {{ partial "separator.html" (dict "modifier" "blog") }}
-            </div>
+            
+            <footer class="article__footer">
+                {{- if $tags -}}
+                    {{- partial "tags.html" (dict "modifier" "large" "tags" $tags ) -}} 
+                {{- end -}}
+            </footer>
         </div>
     </article>
 

--- a/hugo/layouts/docs/list.html
+++ b/hugo/layouts/docs/list.html
@@ -15,8 +15,6 @@
                         {{ partial "paging/section-index.html" . }}
                     </div>
 
-                    {{ partial "separator.html" }}
-
                     <footer class="article__footer">
                         {{ partial "last-modified.html" . }}
                     </footer>

--- a/hugo/layouts/docs/single.html
+++ b/hugo/layouts/docs/single.html
@@ -1,4 +1,10 @@
 {{ define "main" }}
+{{ $tags := slice }}
+{{- if .Params.tags -}}
+    {{ $tagOptions := .Site.Params.Tags | default slice }}
+    {{ $tags = where $tagOptions "name" "in" .Params.tags | default slice }}
+{{- end -}}
+
     <div class="docs" data-docs>
         <div class="docs__main">
             {{ partial "paging/breadcrumb.html" . }}
@@ -6,9 +12,7 @@
 
             <article class="article article--docs">
                 <div class="article__container">
-                    <header class="article__header">
-                        <h1 class="article__title">{{ .Title }}</h1>
-                    </header>
+                    {{ partial "article--header" . }}
 
                     <div class="article__content">
                         {{ if .Params.disabled }}
@@ -21,11 +25,13 @@
                         {{ end }}
                     </div>
 
-                    {{ partial "separator.html" }}
-
                     <footer class="article__footer">
                         {{ partial "last-modified.html" . }}
+                        {{- if $tags -}}
+                            {{- partial "tags.html" (dict "modifier" "large" "tags" $tags ) -}} 
+                        {{- end -}}
                     </footer>
+
                 </div>
             </article>
 

--- a/hugo/layouts/docs/tag-overview.html
+++ b/hugo/layouts/docs/tag-overview.html
@@ -16,8 +16,6 @@
                         {{ partial "paging/tag-index.html" . }}
                     </div>
 
-                    {{ partial "separator.html" }}
-
                     <footer class="article__footer">
                         {{ partial "last-modified.html" . }}
                     </footer>

--- a/hugo/layouts/partials/article--header.html
+++ b/hugo/layouts/partials/article--header.html
@@ -1,0 +1,26 @@
+{{ $tags := slice }}
+{{- if .Params.tags -}}
+    {{ $tagOptions := .Site.Params.Tags | default slice }}
+    {{ $tags = where $tagOptions "name" "in" .Params.tags | default slice }}
+{{- end -}}
+
+<header class="article__header{{ if or .Params.meta .Date $tags }} article__header--extended{{ end }}">
+    <h1 class="article__title">{{ .Title }}</h1>
+    {{- if or .Params.meta .Date $tags -}}
+        <div class="article__info">
+            {{- $meta := slice -}}
+            {{- if .Date -}}
+                {{- $meta = $meta | append (dict "type" "date" "value" (.Date.Format ($.Param "time_format"))) -}}
+            {{- end -}}
+            {{- if .Params.meta -}}
+                {{- $meta = $meta | append .Params.meta -}}
+            {{- end -}}
+            {{- if $meta | len -}}
+                <div class="article__meta">{{ partial "meta" $meta }}</div>
+            {{- end -}}
+            {{- if $tags -}}
+                <div class="article__tags">{{- partial "tags.html" (dict "tags" $tags ) -}}</div>
+            {{- end -}}
+        </div>
+    {{- end -}}
+</header>

--- a/hugo/layouts/partials/meta.html
+++ b/hugo/layouts/partials/meta.html
@@ -14,6 +14,7 @@
       - other (== mapped to cue)
 */}}
 {{ $items := . }}
+
 {{ if $items }}
     <ul class="meta">
         {{ range $items }}

--- a/hugo/layouts/partials/tags.html
+++ b/hugo/layouts/partials/tags.html
@@ -1,15 +1,17 @@
-{{ $tags:= .tags| default slice }}
+{{ $tags := .tags | default slice }}
 {{ $listClass := .listClass | default "" }}
 {{ $modifier := .modifier | default "" }}
 
-<ul class="list list--tags{{ if $listClass }} {{ $listClass }}{{ end }}">
-    {{ range $tag := $tags }}
-        <li class="list__item">
-            {{ $tagValue:= cond (strings.Contains $tag.name " ") (printf "\"%s\"" $tag.name) $tag.name }}
-            <a href="/search?q=tag:{{ $tagValue }}"
-               class="tag{{ if $modifier }} tag--{{ $modifier }}{{ end }}{{ if $tag.color }} tag--{{ $tag.color }}{{ end }}">
-                {{ $tag.name }}
-            </a>
-        </li>
-    {{ end }}
-</ul>
+{{ if $tags }}
+    <ul class="list list--tags{{ if $listClass }} {{ $listClass }}{{ end }}">
+        {{- range $tag := $tags -}}
+            <li class="list__item">
+                {{- $tagValue:= cond (strings.Contains $tag.name " ") (printf "\"%s\"" $tag.name) $tag.name -}}
+                <a href="/search?q=tag:{{ $tagValue }}"
+                class="tag{{ if $modifier }} tag--{{ $modifier }}{{ end }}{{ if $tag.color }} tag--{{ $tag.color }}{{ end }}">
+                    {{ $tag.name }}
+                </a>
+            </li>
+        {{- end -}}
+    </ul>
+{{ end }}


### PR DESCRIPTION
This will add tags to the single pages

- in the "tags" partial, the tags from the front-matter of the page
are rendered;

- the front-matter example page has an added section of tags, and tags are
added to it's own front-matter;

- the tags are shown in the article-header on a single page, normal sized,
and in the article-footer on a single page, large sized;

- a new color has been added, c-lavender--light, to highlight tags that
are hovered over of focused on:

- the article--header partial has been created, and is rendered on all single
pages;

- the article meta and tags are put inside article__info, therefore
the margin styling has been moved from the .meta class to the .article__info
class;

- if there are tags, meta-data, or a date provided on the page front-matter,
the article header will receive a modifier "article__header--extended", which
will modify the margins in the header title, the header info and the header
itself;

- the article footer is now styled with a separator, so the separator
is removed from single pages and list pages where it was applied;

- the separator modifier has been removed from separator.scss, since
the article__footer is now styled with a separator;

For https://linear.app/usmedia/issue/CUE-236