### PR TITLE
Hugo: show correct header on blog pages

### DIFF
--- a/content/blog/_en.html
+++ b/content/blog/_en.html
@@ -2,7 +2,4 @@
 title: "Blog overview"
 description: "Blog overview description."
 layout: list
-header_type: default
-cascade:
-  header_type: wide
 ---

--- a/hugo/assets/scss/components/article.scss
+++ b/hugo/assets/scss/components/article.scss
@@ -31,6 +31,7 @@
         @include style-heading-1;
 
         hyphens: auto;
+        margin-top: 0.75rem;
         word-break: break-word;
     }
 

--- a/hugo/content/en/blog/_index.html
+++ b/hugo/content/en/blog/_index.html
@@ -2,7 +2,4 @@
 title: "Blog overview"
 description: "Blog overview description."
 layout: list
-header_type: default
-cascade:
-  header_type: wide
 ---


### PR DESCRIPTION
The header on blog pages should be the same as the header on the example pages.

- Removed the wide header modifier
- Less spacing above article title

Fixes:
- https://linear.app/usmedia/issue/CUE-294
- https://linear.app/usmedia/issue/CUE-298