### PR TITLE
Hugo: align docs content with breadcrumb

### DIFF
--- a/hugo/assets/scss/components/article.scss
+++ b/hugo/assets/scss/components/article.scss
@@ -50,6 +50,7 @@
     }
 
     &--docs {
+        max-width: $w-content;
         padding-top: 0;
 
         h4,
@@ -72,10 +73,6 @@
     }
 
     @include screen($screen-normal) {
-        &__container {
-            padding: 0 1.875rem;
-        }
-
         &--blog {
             #{ $self }__header {
                 margin: 0 (-$p-gutter--large);


### PR DESCRIPTION
- Bigger max-width
- Remove larger padding on the sides

For https://linear.app/usmedia/issue/CUE-300