### PR TITLE
Hugo: search should do OR of content-type

### DIFF
--- a/hugo/assets/ts/helpers/search.ts
+++ b/hugo/assets/ts/helpers/search.ts
@@ -33,9 +33,14 @@ export const getInputNameForFacet = (facet: SearchFacet): SearchInputFacetName =
 export const mapToAlgoliaFilters = (tagsByFacet: SearchFacets, operator: FilterOperator = FilterOperator.AND): string => {
     return Object.keys(tagsByFacet)
         .map((facet) => {
+            const facetOperator = {
+                [SearchInputFacetName.CONTENT_TYPE]: ' OR ',
+                [SearchInputFacetName.TAG]: ' AND ',
+            }[facet] ?? ' AND ';
+
             return `(${ tagsByFacet[facet]
                 .map((label: string) => `${ facet }:"${ label }"`)
-                .join(' AND ') })`;
+                .join(facetOperator) })`;
         })
         .join(` ${ operator } `);
 };


### PR DESCRIPTION
This will modify the Algolia search filter. When you select multiple content-types from the dropdown, the filtering will be based on any of the chosen types. Consequently, the filtering will not hinge on the requirement that all selected content types are present simultaneously.

For https://linear.app/usmedia/issue/CUE-267