### PR TITLE
Hugo: improve distinguishability of inline code

### DIFF
--- a/hugo/assets/scss/base/base.scss
+++ b/hugo/assets/scss/base/base.scss
@@ -339,6 +339,15 @@ code {
     font-style: normal;
     font-weight: inherit;
     line-height: inherit;
+
+    p & {
+        --pre-background-color: #{ $c-grey-blue--lighter };
+
+        background-color: var(--pre-background-color);
+        border: 1px solid var(--pre-border-color);
+        border-radius: 2px;
+        padding: 0 4px;
+    }
 }
 
 pre {


### PR DESCRIPTION
- Added background + border as seen in design
- Only added this when the inline code is inside a p. This because previous wishes to remove the styling from titles

For https://linear.app/usmedia/issue/CUE-279