### PR TITLE
Internal/Hugo: Update Hugo to 0.117.0

### DIFF
--- a/.github/workflows/trybot.yml
+++ b/.github/workflows/trybot.yml
@@ -167,7 +167,7 @@ jobs:
         name: Install Hugo (${{ runner.os }})
         uses: peaceiris/actions-hugo@v2
         with:
-          hugo-version: 0.115.4
+          hugo-version: 0.117.0
           extended: true
       - if: runner.os == 'macOS'
         name: Install Hugo (${{ runner.os }})

--- a/.github/workflows/update_tip.yml
+++ b/.github/workflows/update_tip.yml
@@ -79,7 +79,7 @@ jobs:
         name: Install Hugo (${{ runner.os }})
         uses: peaceiris/actions-hugo@v2
         with:
-          hugo-version: 0.115.4
+          hugo-version: 0.117.0
           extended: true
       - id: go-mod-cache-dir
         name: Get go mod cache directory

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ issue a `cuelang.org: ` prefix.
 
 * [NodeJS](https://nodejs.org/) `v18.x`
 * [Go](https://golang.org/dl/) `>= go1.20` (not needed for only running `hugo`)
-* [Hugo](https://github.com/gohugoio/hugo/releases) `>= v0.111.3`
+* [Hugo](https://github.com/gohugoio/hugo/releases) `>= v0.117.0`
   (["extended"](https://gohugo.io/troubleshooting/faq/#i-get-this-feature-is-not-available-in-your-current-hugo-version)
   binary version)
 * [Docker](https://docs.docker.com/get-docker/) CLI `>= 19.03` (for [`docker

--- a/hugo/README.md
+++ b/hugo/README.md
@@ -5,7 +5,7 @@ This folder contains all hugo code for the website.
 ## Requirements for local development
 
 - [NodeJS](https://nodejs.org/) `== v18.x`
-- [Hugo](https://github.com/gohugoio/hugo/releases) `== v0.108.0`
+- [Hugo](https://github.com/gohugoio/hugo/releases) `== v0.117.0`
 
 ## Developing the site locally
 

--- a/hugo/config/_default/config.toml
+++ b/hugo/config/_default/config.toml
@@ -8,7 +8,7 @@ enableMissingTranslationPlaceholders = true  # Useful when translating
 
 enableRobotsTXT = true # Render robots.txt
 enableGitInfo = true # Will give git-info values to .Lastmod etc.
-disableKinds = ["RSS", "taxonomy", "taxonomyTerm"]
+disableKinds = ["RSS", "taxonomy", "term"]
 disableAliases = true # We use Netlify server-side redirects instead of generated aliases
 
 # Hugo allows theme composition (and inheritance). Precedence is from left to right.

--- a/hugo/config/_default/languages.toml
+++ b/hugo/config/_default/languages.toml
@@ -4,6 +4,7 @@
     contentDir = "content/en"
     languageDirection = "ltr"
     title = "CUE"
-    description = "Validate and define text-based and dynamic configuration"
-    time_format = "January 2, 2006"
     weight = 1
+    [en.params]
+        description = "Validate and define text-based and dynamic configuration"
+        time_format = "January 2, 2006"

--- a/hugo/layouts/_default/list.algolia.json
+++ b/hugo/layouts/_default/list.algolia.json
@@ -18,8 +18,12 @@
     {{ $cutoff := 1000 -}}
     {{ $index := .index -}}
     {{ $skipWords := mul $cutoff $index }}
+    {{ $fileID := replace $page.Title " " "_"|lower }}
+    {{- with $page.File -}}
+        {{- $fileID = .UniqueID -}}
+    {{- end -}}
 
-    {{- $objectID := (print $page.File.UniqueID "_" (add $index 1)) -}}
+    {{- $objectID := (print $fileID "_" (add $index 1)) -}}
     {{- $title :=  $page.Title -}}
     {{- $link := $page.RelPermalink -}}
     {{- $publishDate := $page.PublishDate -}}

--- a/internal/ci/repo/repo.cue
+++ b/internal/ci/repo/repo.cue
@@ -36,7 +36,7 @@ goVersion: "1.20.6"
 nodeVersion: "18.17.0"
 
 // hugoVersion is the version of hugo used in generating our static site
-hugoVersion: "0.115.4"
+hugoVersion: "0.117.0"
 
 // netlifyCLIVersion is the version of the Netlify CLI used to deploy tip and
 // deploy previews of CLs

--- a/netlify.toml
+++ b/netlify.toml
@@ -8,7 +8,7 @@
 [build.environment]
   GO_VERSION = "1.20.6"
   HUGO_ENV = "production"
-  HUGO_VERSION = "0.115.4"
+  HUGO_VERSION = "0.117.0"
   NODE_VERSION = "18.17.0"
 
 [context.deploy-preview]


### PR DESCRIPTION
- Update Hugo to 0.117.0
- Change needed Hugo version in readme
- Fix deprecated warnings for - languages.toml - config.toml
- Fix warning for .File.UniqueID: added a `with` for the .File

For https://linear.app/usmedia/issue/CUE-243