### PR TITLE
Hugo: add link to sitemap in robots.txt

### DIFF
--- a/hugo/layouts/robots.txt
+++ b/hugo/layouts/robots.txt
@@ -1,0 +1,4 @@
+User-agent: *
+Allow: /
+
+Sitemap: {{ absURL "sitemap.xml" }}


### PR DESCRIPTION
- Created robots.txt to override the autogenerated robots.txt (by Hugo)
- Added the sitemap link to the robots.txt
- https://gohugo.io/templates/robots/
- To test: /robots.txt

For https://linear.app/usmedia/issue/CUE-293