### PR TITLE
hugo: LHS nav improvements

### DIFF
--- a/content/docs/howto/best-practices/en.md
+++ b/content/docs/howto/best-practices/en.md
@@ -4,4 +4,5 @@ weight: 50
 draft: false
 layout: tag-overview
 tag: Best practices
+toc_hide: true
 ---

--- a/content/docs/howto/encode-json-yaml-with-cue/en.md
+++ b/content/docs/howto/encode-json-yaml-with-cue/en.md
@@ -2,6 +2,7 @@
 title: Encode JSON or YAML with CUE
 weight:
 draft: false
+toc_hide: true
 tags:
     - Use encodings in CUE
 ---

--- a/content/docs/howto/ensure-min-max-list/en.md
+++ b/content/docs/howto/ensure-min-max-list/en.md
@@ -2,6 +2,7 @@
 title: Require min or max items in a list
 weight:
 draft: false
+toc_hide: true
 tags:
     - Language
 ---

--- a/content/docs/howto/list-no-duplicates/en.md
+++ b/content/docs/howto/list-no-duplicates/en.md
@@ -2,6 +2,7 @@
 title: Ensure lists have no duplicate items
 weight:
 draft: false
+toc_hide: true
 tags:
     - Language
 ---

--- a/content/docs/howto/use-cue-with-github-actions/en.md
+++ b/content/docs/howto/use-cue-with-github-actions/en.md
@@ -2,6 +2,7 @@
 title: How to use CUE with GitHub Actions
 weight:
 draft: false
+toc_hide: true
 tags:
     - Ecosystem
 ---

--- a/content/docs/howto/use-the-preprocessor/en.md
+++ b/content/docs/howto/use-the-preprocessor/en.md
@@ -2,6 +2,7 @@
 title: How to use the preprocessor
 weight:
 draft: false
+toc_hide: true
 tags:
     - Ecosystem
 ---

--- a/content/docs/howto/validate-json-using-cue/en.md
+++ b/content/docs/howto/validate-json-using-cue/en.md
@@ -1,6 +1,7 @@
 ---
 title: How to validate JSON using CUE
 weight:
+toc_hide: true
 tags:
     - cue command
 ---

--- a/content/docs/howto/validate-yaml-using-cue/en.md
+++ b/content/docs/howto/validate-yaml-using-cue/en.md
@@ -2,6 +2,7 @@
 title: How to validate YAML using CUE
 weight:
 draft: false
+toc_hide: true
 tags:
     - cue command
 ---

--- a/hugo/assets/scss/components/tree.scss
+++ b/hugo/assets/scss/components/tree.scss
@@ -10,7 +10,7 @@
     line-height: 1.75;
     margin: 0 0 1rem;
     overflow: auto;
-    padding: 0 2rem 0.5rem;
+    padding: 0.7rem 0 0.5rem 1rem;
 
     &__list {
         @include list-reset;
@@ -40,11 +40,26 @@
                 background-size: 0 0;
             }
         }
+
+        &:hover,
+        &:focus {
+            #{ $self }__text {
+                background-position-x: 0;
+                background-size: 100% 2px;
+            }
+        }
     }
 
     &__text {
+        background: linear-gradient(
+        var(--tree-chapter-background, $c-yellow),
+        var(--tree-chapter-background, $c-yellow)
+    ) no-repeat 100% 100%;
+        background-size: 0 2px;
         display: inline;
-        font-weight: $weight-bold;
+        font-size: 1rem;
+        font-weight: $weight-medium;
+        transition: background-color 0.2s ease-in-out, background-size 0.2s ease-in-out;
     }
 
     .is-book {
@@ -53,38 +68,29 @@
         }
 
         & > #{ $self }__item {
+            padding: 0.7rem 2rem;
+
             & > .toc {
                 margin-left: 0;
                 margin-top: 0.5rem;
             }
 
-            &.has-children {
-                margin-bottom: 1.75rem;
-            }
-        }
-
-        #{ $self }__item {
-            margin-top: 0.75rem;
-
-            &.is-active {
-                #{ $self }__link {
-                    border-color: var(--tree-book-link-border-active, $c-yellow);
+            & > #{ $self }__link {
+                #{ $self }__text {
+                    font-size: 1.25rem;
+                    font-weight: $weight-bold;
                 }
             }
 
-            #{ $self }__link {
-                border-bottom: 1px solid var(--tree-book-link-border, transparentize($c-blue, 0.7));
-                transition: border-color 0.2s;
-
-                &:hover,
-                &:focus {
-                    border-color: var(--tree-book-link-border-hover, $c-yellow);
-                }
+            &.is-active,
+            &.is-active-path {
+                background: $c-grey--light-mid;
+                border-radius: $b-radius 0 0 $b-radius;
+                box-shadow: 4px 4px 10px 0 transparentize($c-black, 0.98) inset;
+                padding-bottom: 1.5rem;
+                padding-top: 1rem;
             }
 
-            #{ $self }__text {
-                font-size: 1.25rem;
-            }
         }
     }
 
@@ -108,30 +114,14 @@
             }
 
             #{ $self }__link {
-                border-bottom: none;
-                margin-bottom: 0;
                 padding: 0.25rem 0;
-                transition: none;
 
                 &:hover,
                 &:focus {
                     #{ $self }__text {
-                        background-position-x: 0;
-                        background-size: 100% 1px;
                         color: $c-blue--light;
                     }
                 }
-            }
-
-            #{ $self }__text {
-                background: linear-gradient(
-                    var(--tree-chapter-background, $c-yellow),
-                    var(--tree-chapter-background, $c-yellow)
-                ) no-repeat 100% 100%;
-                background-size: 0 1px;
-                font-size: 1rem;
-                font-weight: $weight-medium;
-                transition: background-color 0.2s ease-in-out, background-size 0.2s ease-in-out;
             }
         }
     }

--- a/hugo/assets/scss/config/colors.scss
+++ b/hugo/assets/scss/config/colors.scss
@@ -1,5 +1,6 @@
 $c-blue--lightest:      #f8f9fd;
 $c-blue--lighter:       #f0f2fb;
+$c-grey--light-mid:     #e6e8f3;
 $c-blue--light:         #1b3987;
 $c-blue:                #232a68;
 $c-blue--dark:          #0c2c65;

--- a/hugo/content/en/docs/howto/best-practices/index.md
+++ b/hugo/content/en/docs/howto/best-practices/index.md
@@ -4,4 +4,5 @@ weight: 50
 draft: false
 layout: tag-overview
 tag: Best practices
+toc_hide: true
 ---

--- a/hugo/content/en/docs/howto/encode-json-yaml-with-cue/index.md
+++ b/hugo/content/en/docs/howto/encode-json-yaml-with-cue/index.md
@@ -2,6 +2,7 @@
 title: Encode JSON or YAML with CUE
 weight:
 draft: false
+toc_hide: true
 tags:
     - Use encodings in CUE
 ---

--- a/hugo/content/en/docs/howto/ensure-min-max-list/index.md
+++ b/hugo/content/en/docs/howto/ensure-min-max-list/index.md
@@ -2,6 +2,7 @@
 title: Require min or max items in a list
 weight:
 draft: false
+toc_hide: true
 tags:
     - Language
 ---

--- a/hugo/content/en/docs/howto/list-no-duplicates/index.md
+++ b/hugo/content/en/docs/howto/list-no-duplicates/index.md
@@ -2,6 +2,7 @@
 title: Ensure lists have no duplicate items
 weight:
 draft: false
+toc_hide: true
 tags:
     - Language
 ---

--- a/hugo/content/en/docs/howto/use-cue-with-github-actions/index.md
+++ b/hugo/content/en/docs/howto/use-cue-with-github-actions/index.md
@@ -2,6 +2,7 @@
 title: How to use CUE with GitHub Actions
 weight:
 draft: false
+toc_hide: true
 tags:
     - Ecosystem
 ---

--- a/hugo/content/en/docs/howto/use-the-preprocessor/index.md
+++ b/hugo/content/en/docs/howto/use-the-preprocessor/index.md
@@ -2,6 +2,7 @@
 title: How to use the preprocessor
 weight:
 draft: false
+toc_hide: true
 tags:
     - Ecosystem
 ---

--- a/hugo/content/en/docs/howto/validate-json-using-cue/index.md
+++ b/hugo/content/en/docs/howto/validate-json-using-cue/index.md
@@ -1,6 +1,7 @@
 ---
 title: How to validate JSON using CUE
 weight:
+toc_hide: true
 tags:
     - cue command
 ---

--- a/hugo/content/en/docs/howto/validate-yaml-using-cue/index.md
+++ b/hugo/content/en/docs/howto/validate-yaml-using-cue/index.md
@@ -2,6 +2,7 @@
 title: How to validate YAML using CUE
 weight:
 draft: false
+toc_hide: true
 tags:
     - cue command
 ---

--- a/hugo/layouts/partials/paging/tree.html
+++ b/hugo/layouts/partials/paging/tree.html
@@ -52,22 +52,15 @@
     {{ $isActiveChapter := .isActiveChapter -}}
     {{ $isActive := (eq $s $p) -}}
     {{ $isActivePath := ($p.IsDescendant $s) -}}
-    {{ $isTagOverview := eq $s.Params.layout "tag-overview" -}}
 
     {{ $pages := where (union $s.Pages $s.Sections).ByWeight ".Params.toc_hide" "!=" true -}}
-
-    {{ if $isTagOverview }}
-        {{ $tag := $s.Params.tag -}}
-        {{ $isActivePath = and $isActiveChapter (in $p.Params.tags $tag) -}}
-        {{ $pages = where (union $s.Parent.Pages $s.Parent.Sections).ByWeight ".Params.toc_hide" "!=" true -}}
-        {{ $pages = (where $pages ".Params.tags" "intersect" (slice $tag) ) -}}
-    {{- end }}
 
     {{- $isPage := gt (add $depth 1) 2 }}
     {{- $isPageOfInactivePath := cond $isActive false (and $isPage (not $isActivePath)) }}
     {{ $withChildren := and (gt (len $pages) 0) (ne $depth $maxDepth) (not $isPageOfInactivePath) -}}
+    {{ $showChildren := and (or $isActive $isActivePath $isActiveChapter) $withChildren }}
 
-    <li class="tree__item{{ if $withChildren }} has-children{{ end }}{{ if $isActivePath }} is-active-path{{ end }}{{ if $isActive }} is-active{{ end }}">
+    <li class="tree__item{{ if $showChildren }} has-children{{ end }}{{ if $isActivePath }} is-active-path{{ end }}{{ if $isActive }} is-active{{ end }}">
         <a class="tree__link" href="{{ $s.RelPermalink }}" title="{{ $s.LinkTitle }}"{{ if $s.Params.disabled }} disabled{{ end }}>
             <span class="tree__text">{{ $s.LinkTitle }}</span>
         </a>
@@ -75,13 +68,13 @@
         {{- if $isActive }}
             {{ partial "paging/table-of-contents.html" (dict "toc" $toc) }}
         {{- end }}
-        {{- if $withChildren }}
+
+        {{- if $showChildren }}
             {{- $depth := add $depth 1 }}
             <ul class="tree__list {{ if gt $depth 2 }}is-page{{ else }}is-chapter{{ end }}">
                 {{ range $pages -}}
-                    {{- $chapterWithTag := and (eq $depth 2) (isset .Params "tags") }}
                     {{- $isRoot := (and (eq $s $p.Site.Home) (eq .Params.toc_root true)) }}
-                    {{ if and (not $isRoot) (not $chapterWithTag) -}}
+                    {{ if and (not $isRoot) -}}
                         {{ template "tree-nav-section" (dict
                             "page" $p
                             "section" .


### PR DESCRIPTION
- Collapse tree items of non-active chapters, only show children if current page is the active chapter or a descendant of the active chapter
- Add styling to the active chapter top-level item. Switch some margins to paddings to make this possible.
- Move the styling for the border on hover to the main link/text in tree.scss because the same style is now used for every link in the tree
- Remove automatic hiding of tags pages for left hand nav
- Add `toc_hide: true` to docs pages with tags that were already not showing because of the previous tagged-pages-behaviour.

- Note: You can add the `toc_hide: true` in the front-matter to any page you don't want so show in the lhs nav. The tag overview pages can be removed if you don't need them anymore but I leave that up to CUE.

For https://linear.app/usmedia/issue/CUE-282

Test on docs pages. For instance https://deploy-preview-395--cue.netlify.app/docs/language-guide/templating/