### PR TITLE
Hugo: more padding so search icon does not get cut off

### DIFF
--- a/hugo/assets/scss/components/searchbar.scss
+++ b/hugo/assets/scss/components/searchbar.scss
@@ -157,7 +157,7 @@
         &--small {
             #{ $self }__form {
                 height: $h-button--small + 16px;
-                padding: 0 1.125rem 0 2.5rem;
+                padding: 0 1.125rem 0 2.75rem;
             }
 
             #{ $self }__label {


### PR DESCRIPTION
- Added more padding to the searchbar so the input part doesn't move over the search icon

For https://linear.app/usmedia/issue/CUE-272