### PR TITLE
hugo: Fix js error which triggers when codeToCopy is set to false

### DIFF
--- a/hugo/layouts/_default/_markup/render-codeblock.html
+++ b/hugo/layouts/_default/_markup/render-codeblock.html
@@ -4,7 +4,8 @@
 {{- $showCopyButton := ne (index .Attributes "codetocopy") false -}}
 {{- $codeToCopy := index .Attributes "codetocopy" | default (.Inner | base64Encode) -}}
 
-<div class="code-block{{ if $title }} code-block--heading{{ end }}{{ if eq $type "terminal" }} code-block--terminal{{ end }}{{ if $modifier }} {{ $modifier}}{{ end }}" data-copy>
+<div class="code-block{{ if $title }} code-block--heading{{ end }}{{ if eq $type "terminal" }} code-block--terminal{{ end }}
+{{ if $modifier }} {{ $modifier}}{{ end }}"{{- if $showCopyButton -}} data-copy{{- end -}}>
     {{- with $title -}}
         <div class="code-block__heading">
             <span class="code-block__tab">{{- . -}}</span>


### PR DESCRIPTION
- Only add data-copy when showCopyButton is set to true to avoid loading the copy javascript when it's not needed (and not working)

To test: Go to '/examples/basic/code-block/'. Previously this showed an error
in the console for codeblock with codeToCopy set to false. Now the error is
gone.

For https://linear.app/usmedia/issue/CUE-311