### PR TITLE
Hugo: less spacing when sections are of the same color

### DIFF
--- a/hugo/assets/scss/components/section.scss
+++ b/hugo/assets/scss/components/section.scss
@@ -88,41 +88,11 @@
         }
     }
 
-    &--white {
-        --section-bg-color: #{ $c-white };
+    @each $theme, $color in $themes {
+        &--#{ $theme } {
+            --section-bg-color: #{ $color };
 
-        + #{ $self }--white {
-            & > :first-child {
-                padding-top: 0;
-            }
-        }
-    }
-
-    &--blue {
-        --section-bg-color: #{ $c-blue--lighter };
-
-        + #{ $self }--blue {
-            & > :first-child {
-                padding-top: 0;
-            }
-        }
-    }
-
-    &--grey {
-        --section-bg-color: #{ $c-grey--lightest };
-
-        + #{ $self }--grey {
-            & > :first-child {
-                padding-top: 0;
-            }
-        }
-    }
-
-    &--yellow {
-        --section-bg-color: #{ $c-yellow };
-
-        + #{ $self }--yellow {
-            & > :first-child {
+            + #{ $self }--#{ $theme } {
                 padding-top: 0;
             }
         }

--- a/hugo/assets/scss/config/colors.scss
+++ b/hugo/assets/scss/config/colors.scss
@@ -72,3 +72,11 @@ $shadow--header:        0 3px 12px transparentize($c-blue--dark, .8);
 $shadow--drawer:        0 3px 12px transparentize($c-blue--dark, .8);
 
 $shadow--button:        0 3px 1px -2px #0003, 0 2px 2px #00000024, 0 1px 5px #0000001f;
+
+// Themes:
+$themes: (
+    'white': $c-white,
+    'blue': $c-blue--lighter,
+    'grey': $c-grey--lightest,
+    'yellow': $c-yellow,
+);


### PR DESCRIPTION
As can be seen on the homepage, sections with the same background color have less spacing between them.

- Added themes variable to colors
- Used themes variable to loop over section color modifiers
- Used the loop to remove padding top when sections of the same color are next to eachother

For https://linear.app/usmedia/issue/CUE-307