### PR TITLE
hugo: LHS nav: show active item in tree

### DIFF
--- a/hugo/layouts/partials/paging/tree.html
+++ b/hugo/layouts/partials/paging/tree.html
@@ -53,7 +53,13 @@
     {{ $isActive := (eq $s $p) -}}
     {{ $isActivePath := ($p.IsDescendant $s) -}}
 
-    {{ $pages := where (union $s.Pages $s.Sections).ByWeight ".Params.toc_hide" "!=" true -}}
+    {{ $pages := slice }}
+    {{/* Only add pages that are active or have toc_hide set to false */}}
+    {{ range (union $s.Pages $s.Sections).ByWeight -}}
+        {{ if or (eq . $p) (ne .Params.toc_hide true) -}}
+            {{ $pages = $pages | append . }}
+        {{- end }}
+    {{- end }}
 
     {{- $isPage := gt (add $depth 1) 2 }}
     {{- $isPageOfInactivePath := cond $isActive false (and $isPage (not $isActivePath)) }}


### PR DESCRIPTION
Ignore the param 'toc_hide: true' for active items so the active item shows up in the nav-tree again because:
1. In order the see the table of contents the item needs to show in the left hand nav
2. To make clear where the active item lives in the current tree.

To test:
- Click on How-To guides: The page 'Encode JSON or YAML with CUE' doesn't show up here because toc_hide is set to true.
 - Now go to this page  (/docs/howto/encode-json-yaml-with-cue/): the page now does show up in the lhs nav because it's active and also the table of contents is showing again (in current alpha when going to the same page it does not show up in the nav and therefore the table of contents is also not visible)

For https://linear.app/usmedia/issue/CUE-282