### PR TITLE
Hugo: add spotlight shortcode

### DIFF
--- a/content/blog/example/en.md
+++ b/content/blog/example/en.md
@@ -33,3 +33,17 @@ Pellentesque habitant morbi tristique senectus et netus et malesuada fames ac tu
 [Official CUE releases](https://github.com/cue-lang/cue/releases/)
 
 Pellentesque habitant morbi tristique senectus et netus et malesuada fames ac turpis egestas. Vestibulum tortor quam, feugiat vitae, ultricies eget, tempor sit amet, ante. Donec eu libero sit amet quam egestas semper. Aenean ultricies mi vitae est. Mauris placerat eleifend leo. Quisque sit amet est et sapien ullamcorper pharetra. Vestibulum erat wisi, condimentum sed, commodo vitae, ornare sit amet, wisi.
+
+{{< spotlight title="Related content" >}}
+
+### Documentation
+
+-   [**Validation** Lorem ipsum dolor sit amet conamentum senectus donec. Id risus ornare risus pulvinar.]({{< ref "docs/howto/validate-json-using-cue" >}})
+-   [**References** Conamentum senectus donec. Id risus ornare risus pulvinar.]({{< ref "docs/reference/code-of-conduct" >}})
+
+### Blog posts
+- [Take a cue to supercharge your configurations]({{< ref "blog/example2" >}})
+- [Cue changes the way we validate our research date]({{< ref "blog/example3" >}})
+- [Take a cue to supercharge your configurations]({{< ref "blog/example4" >}})
+
+{{< /spotlight >}}

--- a/content/docs/howto/encode-json-yaml-with-cue/en.md
+++ b/content/docs/howto/encode-json-yaml-with-cue/en.md
@@ -20,12 +20,16 @@ It may be necessary to include **nested data** as an encoded string, such as a b
 of YAML embedded as a string inside a JSON request. The steps below show how to
 accomplish that with the `cue` command line. First with JSON, then with YAML.
 
-## Prerequisites
+{{< spotlight >}}
+
+### Prerequisites
 
 -   You have [CUE installed](https://cuelang.org/docs/install/) locally. This
     allows you to run `cue` commands
 -   You know how to use [CUE Definitions/ Helper Fields]({{< ref
     "/docs/language-guide/data" >}})
+
+{{< /spotlight >}}
 
 ## Encoding Nested JSON
 

--- a/content/examples/_en.html
+++ b/content/examples/_en.html
@@ -96,6 +96,11 @@ description: "View examples on how to use certain possible elements of the theme
 
                     <ul class="nav__list">
                         <li class="nav__item">
+                            <a class="nav__link" href="/examples/shortcodes/spotlight/">
+                                <span class="nav__text">Spotlight</span>
+                            </a>
+                        </li>
+                        <li class="nav__item">
                             <a class="nav__link" href="/examples/shortcodes/info/">
                                 <span class="nav__text">Info Block</span>
                             </a>

--- a/content/examples/shortcodes/spotlight/en.md
+++ b/content/examples/shortcodes/spotlight/en.md
@@ -1,0 +1,64 @@
+---
+title: Spotlight
+weight: 25
+---
+
+Use this shortcode to e.g. spotlight the prerequisites or related content.
+
+In order to spotlight some content, you can use `{{</* spotlight */>}}`.
+
+```
+{{</* spotlight */>}}
+
+## Prerequisites
+
+- **A tool to edit text files.** Any text editor you have will be fine. Some popular text editors are VSCode, Vim, Nano, and Emacs; but if you need to use Notepad that will work fine.
+- **A command terminal.** `cue` works well using any terminal on Linux and Mac, and on PowerShell or `cmd.exe` in Windows.
+
+{{</* /spotlight */>}}
+```
+
+The rendered output looks like this:
+
+{{< spotlight >}}
+
+## Prerequisites
+
+-   **A tool to edit text files.** Any text editor you have will be fine. Some popular text editors are VSCode, Vim, Nano, and Emacs; but if you need to use Notepad that will work fine.
+-   **A command terminal.** `cue` works well using any terminal on Linux and Mac, and on PowerShell or `cmd.exe` in Windows.
+
+{{< /spotlight >}}
+
+## Attributes
+
+title
+: optional - add a title width a bottom border. The title gets an h2, therefore it is recommended that when you are using headings inside the spotlight you only use h3-6.
+
+theme
+: options - default is `blue`, other option is `yellow`.
+
+Also, if the spotlight is the last part of the content (like when it is used for the related content), there is more whitespace above the spotlight.
+
+## Example
+
+```
+{{</* spotlight title="Related content" theme="yellow" */>}}
+
+### Prerequisites
+
+- **A tool to edit text files.** Any text editor you have will be fine. Some popular text editors are VSCode, Vim, Nano, and Emacs; but if you need to use Notepad that will work fine.
+- **A command terminal.** `cue` works well using any terminal on Linux and Mac, and on PowerShell or `cmd.exe` in Windows.
+
+{{</* /spotlight */>}}
+```
+
+The rendered output looks like this:
+
+{{< spotlight title="Related content" theme="yellow" >}}
+
+### Prerequisites
+
+-   **A tool to edit text files.** Any text editor you have will be fine. Some popular text editors are VSCode, Vim, Nano, and Emacs; but if you need to use Notepad that will work fine.
+-   **A command terminal.** `cue` works well using any terminal on Linux and Mac, and on PowerShell or `cmd.exe` in Windows.
+
+{{< /spotlight >}}

--- a/content/examples/shortcodes/spotlight/page.cue
+++ b/content/examples/shortcodes/spotlight/page.cue
@@ -1,0 +1,3 @@
+package site
+
+"examples": "shortcodes": "spotlight": {}

--- a/hugo/assets/scss/components/article.scss
+++ b/hugo/assets/scss/components/article.scss
@@ -154,5 +154,13 @@
         &__meta {
             margin-right: auto;
         }
+
+        &--docs {
+            .spotlight {
+                margin-left: 0;
+                margin-right: 0;
+                padding: 1.75rem $p-gutter--large;
+            }
+        }
     }
 }

--- a/hugo/assets/scss/components/spotlight.scss
+++ b/hugo/assets/scss/components/spotlight.scss
@@ -1,0 +1,53 @@
+@import '../config/colors';
+@import '../mixins/marginless-child';
+@import '../mixins/screen';
+@import '../mixins/typography';
+
+.spotlight {
+    $self: &;
+
+    background-color: var(--spotlight-bg-color, $c-blue--lighter);
+    margin: 0 (-$p-gutter) 1.5rem;
+    padding: $p-gutter--large $p-gutter;
+
+    &:last-child {
+        margin-top: 3rem;
+    }
+
+    &__title {
+        @include style-heading-2;
+
+        --heading-color: #{ $c-blue--darker };
+
+        border-bottom: 1px solid transparentize($c-blue--darker, 0.8);
+        margin: 0 0 1.5rem;
+        padding-bottom: 1.5rem;
+    }
+
+    &__content {
+        @include marginless-child;
+
+        --heading-color: #{ $c-grey--darkest };
+        --text-link-color: #{ $c-grey--darkest};
+
+        color: var(--spotlight-text-color, $c-grey--darkest);
+    }
+
+    &--yellow {
+        --spotlight-bg-color: #{ $c-yellow--light }
+    }
+
+    @include screen($screen-normal) {
+        border-radius: $b-radius;
+        margin: 0 (-50px) 1.5rem; // 50px because of difference between article container and content container
+        padding: 3rem 50px; // 50px because of difference between article container and content container
+
+        &:last-child {
+            margin-top: 5rem;
+        }
+
+        .anchor {
+            left: -1.5rem;
+        }
+    }
+}

--- a/hugo/assets/scss/main.scss
+++ b/hugo/assets/scss/main.scss
@@ -53,6 +53,7 @@
 @import 'components/share';
 @import 'components/sidenote';
 @import 'components/spinner';
+@import 'components/spotlight';
 @import 'components/step';
 @import 'components/tabs';
 @import 'components/tabs-nav';

--- a/hugo/content/en/blog/example/index.md
+++ b/hugo/content/en/blog/example/index.md
@@ -33,3 +33,17 @@ Pellentesque habitant morbi tristique senectus et netus et malesuada fames ac tu
 [Official CUE releases](https://github.com/cue-lang/cue/releases/)
 
 Pellentesque habitant morbi tristique senectus et netus et malesuada fames ac turpis egestas. Vestibulum tortor quam, feugiat vitae, ultricies eget, tempor sit amet, ante. Donec eu libero sit amet quam egestas semper. Aenean ultricies mi vitae est. Mauris placerat eleifend leo. Quisque sit amet est et sapien ullamcorper pharetra. Vestibulum erat wisi, condimentum sed, commodo vitae, ornare sit amet, wisi.
+
+{{< spotlight title="Related content" >}}
+
+### Documentation
+
+-   [**Validation** Lorem ipsum dolor sit amet conamentum senectus donec. Id risus ornare risus pulvinar.]({{< ref "docs/howto/validate-json-using-cue" >}})
+-   [**References** Conamentum senectus donec. Id risus ornare risus pulvinar.]({{< ref "docs/reference/code-of-conduct" >}})
+
+### Blog posts
+- [Take a cue to supercharge your configurations]({{< ref "blog/example2" >}})
+- [Cue changes the way we validate our research date]({{< ref "blog/example3" >}})
+- [Take a cue to supercharge your configurations]({{< ref "blog/example4" >}})
+
+{{< /spotlight >}}

--- a/hugo/content/en/docs/howto/encode-json-yaml-with-cue/index.md
+++ b/hugo/content/en/docs/howto/encode-json-yaml-with-cue/index.md
@@ -20,12 +20,16 @@ It may be necessary to include **nested data** as an encoded string, such as a b
 of YAML embedded as a string inside a JSON request. The steps below show how to
 accomplish that with the `cue` command line. First with JSON, then with YAML.
 
-## Prerequisites
+{{< spotlight >}}
+
+### Prerequisites
 
 -   You have [CUE installed](https://cuelang.org/docs/install/) locally. This
     allows you to run `cue` commands
 -   You know how to use [CUE Definitions/ Helper Fields]({{< ref
     "/docs/language-guide/data" >}})
+
+{{< /spotlight >}}
 
 ## Encoding Nested JSON
 

--- a/hugo/content/en/examples/_index.html
+++ b/hugo/content/en/examples/_index.html
@@ -96,6 +96,11 @@ description: "View examples on how to use certain possible elements of the theme
 
                     <ul class="nav__list">
                         <li class="nav__item">
+                            <a class="nav__link" href="/examples/shortcodes/spotlight/">
+                                <span class="nav__text">Spotlight</span>
+                            </a>
+                        </li>
+                        <li class="nav__item">
                             <a class="nav__link" href="/examples/shortcodes/info/">
                                 <span class="nav__text">Info Block</span>
                             </a>

--- a/hugo/content/en/examples/shortcodes/spotlight/index.md
+++ b/hugo/content/en/examples/shortcodes/spotlight/index.md
@@ -1,0 +1,64 @@
+---
+title: Spotlight
+weight: 25
+---
+
+Use this shortcode to e.g. spotlight the prerequisites or related content.
+
+In order to spotlight some content, you can use `{{</* spotlight */>}}`.
+
+```
+{{</* spotlight */>}}
+
+## Prerequisites
+
+- **A tool to edit text files.** Any text editor you have will be fine. Some popular text editors are VSCode, Vim, Nano, and Emacs; but if you need to use Notepad that will work fine.
+- **A command terminal.** `cue` works well using any terminal on Linux and Mac, and on PowerShell or `cmd.exe` in Windows.
+
+{{</* /spotlight */>}}
+```
+
+The rendered output looks like this:
+
+{{< spotlight >}}
+
+## Prerequisites
+
+-   **A tool to edit text files.** Any text editor you have will be fine. Some popular text editors are VSCode, Vim, Nano, and Emacs; but if you need to use Notepad that will work fine.
+-   **A command terminal.** `cue` works well using any terminal on Linux and Mac, and on PowerShell or `cmd.exe` in Windows.
+
+{{< /spotlight >}}
+
+## Attributes
+
+title
+: optional - add a title width a bottom border. The title gets an h2, therefore it is recommended that when you are using headings inside the spotlight you only use h3-6.
+
+theme
+: options - default is `blue`, other option is `yellow`.
+
+Also, if the spotlight is the last part of the content (like when it is used for the related content), there is more whitespace above the spotlight.
+
+## Example
+
+```
+{{</* spotlight title="Related content" theme="yellow" */>}}
+
+### Prerequisites
+
+- **A tool to edit text files.** Any text editor you have will be fine. Some popular text editors are VSCode, Vim, Nano, and Emacs; but if you need to use Notepad that will work fine.
+- **A command terminal.** `cue` works well using any terminal on Linux and Mac, and on PowerShell or `cmd.exe` in Windows.
+
+{{</* /spotlight */>}}
+```
+
+The rendered output looks like this:
+
+{{< spotlight title="Related content" theme="yellow" >}}
+
+### Prerequisites
+
+-   **A tool to edit text files.** Any text editor you have will be fine. Some popular text editors are VSCode, Vim, Nano, and Emacs; but if you need to use Notepad that will work fine.
+-   **A command terminal.** `cue` works well using any terminal on Linux and Mac, and on PowerShell or `cmd.exe` in Windows.
+
+{{< /spotlight >}}

--- a/hugo/layouts/shortcodes/spotlight.html
+++ b/hugo/layouts/shortcodes/spotlight.html
@@ -1,0 +1,16 @@
+{{- $title := .Get "title" | default false -}}
+{{- $theme := .Get "theme" | default "blue" -}}
+
+<div class="spotlight{{if $theme }} spotlight--{{ $theme }}{{ end }}">
+    {{ with $title }}
+        <h2 class="spotlight__title">{{ . }}</h2>
+    {{ end }}
+
+    <div class="spotlight__content">
+        {{ if eq .Page.File.Ext "md" -}}
+            {{ .Inner | markdownify }}
+        {{ else -}}
+            {{ .Inner | htmlUnescape | safeHTML }}
+        {{- end }}
+    </div>
+</div>


### PR DESCRIPTION
- Added spotlight example page (/examples/shortcodes/spotlight/)
- Added link on example overview (/examples/)
- Added Related content example to blog example page (/blog/example/)
- Set up spotlight shortcode
- Added spotlight styling

For https://linear.app/usmedia/issue/CUE-308