### PR TITLE
hugo: Fine tune code-tabs height

### DIFF
--- a/content/examples/shortcodes/code-tabs/en.md
+++ b/content/examples/shortcodes/code-tabs/en.md
@@ -82,6 +82,11 @@ groupId
 : optional - Determine if tabs should be synced as port of a group.
 If you add a groupId the selected tab will be synced across tabs with the same groupId.
 
+limitHeight
+: optional - value: true/false (omitting this attribute is same as false)
+Determine if the tabs should have a height. By default it fits the content of the tabs.
+By setting it to true it has a height of 500px.  This can be used if tabs contain long content.
+
 ## Attributes on code-tab
 
 name
@@ -241,9 +246,9 @@ languages.1.name: invalid value "dutch" (does not match =~"^\\p{Lu}"):
 
 {{< /code-tabs >}}
 
-### 2 tabs in top-left, 1 in bottom-left,  1 in top-right and 1 in bottom-right
+### 2 tabs in top-left, 1 in bottom-left, 1 in top-right and 1 in bottom-right with limitHeight set to true
 
-{{< code-tabs >}}
+{{< code-tabs limitHeight=true >}}
 
 {{< code-tab name="schema.cue" area="top-left" >}}
 #Language: {

--- a/hugo/assets/scss/components/code-tabs.scss
+++ b/hugo/assets/scss/components/code-tabs.scss
@@ -26,14 +26,12 @@
 
     @include screen($screen-simple) {
         display: grid;
-        grid-template:
-            'topLeft topRight' fit-content(248px)
-            'bottomLeft bottomRight' fit-content(248px) / 50% 50%;
-        max-height: 500px;
+        grid-template-areas:
+            'topLeft topRight'
+            'bottomLeft bottomRight';
+        grid-template-columns: 50% 50%;
 
         &__item {
-            max-height: 248px;
-
             &:only-child {
                 grid-column: span 2;
             }
@@ -42,7 +40,6 @@
                 border-bottom: 0;
                 grid-area: topLeft;
                 grid-row: span 2;
-                max-height: 500px;
                 resize: horizontal;
             }
 
@@ -51,7 +48,6 @@
                 border-left: 2px solid var(--pre-border-color, $c-grey-blue);
                 grid-area: topRight;
                 grid-row: span 2;
-                max-height: 500px;
             }
 
             &--top-left {
@@ -90,5 +86,10 @@
                 }
             }
         }
+    }
+
+    &--max {
+        grid-template-rows: minmax(0, auto) minmax(0, auto);
+        height: 500px;
     }
 }

--- a/hugo/content/en/examples/shortcodes/code-tabs/index.md
+++ b/hugo/content/en/examples/shortcodes/code-tabs/index.md
@@ -82,6 +82,11 @@ groupId
 : optional - Determine if tabs should be synced as port of a group.
 If you add a groupId the selected tab will be synced across tabs with the same groupId.
 
+limitHeight
+: optional - value: true/false (omitting this attribute is same as false)
+Determine if the tabs should have a height. By default it fits the content of the tabs.
+By setting it to true it has a height of 500px.  This can be used if tabs contain long content.
+
 ## Attributes on code-tab
 
 name
@@ -241,9 +246,9 @@ languages.1.name: invalid value "dutch" (does not match =~"^\\p{Lu}"):
 
 {{< /code-tabs >}}
 
-### 2 tabs in top-left, 1 in bottom-left,  1 in top-right and 1 in bottom-right
+### 2 tabs in top-left, 1 in bottom-left, 1 in top-right and 1 in bottom-right with limitHeight set to true
 
-{{< code-tabs >}}
+{{< code-tabs limitHeight=true >}}
 
 {{< code-tab name="schema.cue" area="top-left" >}}
 #Language: {

--- a/hugo/layouts/shortcodes/code-tabs.html
+++ b/hugo/layouts/shortcodes/code-tabs.html
@@ -1,12 +1,13 @@
 {{ with .Inner }}{{/* don't do anything, just call it because hugo needs it */}}{{ end }}
 
 {{- $groupId := .Get "groupId" | default "default" -}}
+{{- $limitHeight := .Get "limitHeight" | default false -}}
 {{- $tabsTopLeft := .Scratch.Get "tabs-top-left" -}}
 {{- $tabsTopRight := .Scratch.Get "tabs-top-right" -}}
 {{- $tabsBottomLeft := .Scratch.Get "tabs-bottom-left" -}}
 {{- $tabsBottomRight := .Scratch.Get "tabs-bottom-right" -}}
 
-<div class="code-tabs">
+<div class="code-tabs{{ if $limitHeight }} code-tabs--max{{ end }}">
     {{ if $tabsTopLeft }}
         {{- $modifier := cond (not $tabsBottomLeft) "code-tabs__item--left" "code-tabs__item--top-left" -}}
         <div class="code-tabs__item {{ $modifier }}">


### PR DESCRIPTION
- By default the code-tabs grow with the content (no (max) height)
- If you set limitHeight to true the code-tabs will have a set width of 500px. This can be used for code-tabs with long content.
 - Improve css usage of grid so the rows will try to fit the height of the parent instead.

To test: /examples/basic/code-block/

For https://linear.app/usmedia/issue/CUE-321