### PR TITLE
hugo: Fix scroll issues for code-block

### DIFF
--- a/content/examples/basic/code-block/en.md
+++ b/content/examples/basic/code-block/en.md
@@ -54,6 +54,7 @@ You can also use syntax highlighting with Fenced Code Blocks. For this you only 
 
 [Here](https://gohugo.io/content-management/syntax-highlighting/#list-of-chroma-highlighting-languages) is a list of all the languages that can get syntax styling.
 
+You can add line numbers by adding `lineos=true`.
 You can even mark/highlight part of the code by adding `hl_lines` with the according lines you want to highlight:
 
 {{< columns >}}
@@ -79,6 +80,22 @@ You can even mark/highlight part of the code by adding `hl_lines` with the accor
 }
 ```
 {{< /columns >}}
+
+It's also possible to set `lineos=table` if you want to have table html for the line numbers:
+
+```text {title="Table", linenos=table}
+package ci
+
+import (
+	"path"
+	"encoding/yaml"
+	"tool/file"
+
+	// initialised at the start of this guide, followed by the relative path from the repository root to the `github` directory.
+	"github.com/cue-examples/github-actions-example/internal/ci/github"
+)
+
+```
 
 Other options that can be added after defining a language can be found [here](https://gohugo.io/content-management/syntax-highlighting/#highlight-shortcode).
 

--- a/hugo/assets/scss/components/code-block.scss
+++ b/hugo/assets/scss/components/code-block.scss
@@ -7,6 +7,8 @@
 .code-block {
     $self: &;
 
+    border: 2px solid var(--pre-border-color, $c-grey-blue);
+    border-radius: $b-radius;
     display: flex;
     flex-direction: column;
     margin-bottom: 1.5rem;
@@ -19,11 +21,12 @@
         }
     }
 
+    pre {
+        border: 0;
+    }
+
     &__heading {
         background-color: $c-grey-blue--lighter;
-        border: 2px solid var(--pre-border-color, $c-grey-blue);
-        border-bottom: 0;
-        border-radius: $b-radius $b-radius 0 0;
         color: $c-blue--darker;
         flex: 0 0 35px;
     }
@@ -133,8 +136,6 @@
 
     &--heading {
         pre {
-            border-radius: 0 0 $b-radius $b-radius;
-            border-top: 0;
             padding-top: 0.5rem;
         }
     }

--- a/hugo/assets/scss/components/highlight.scss
+++ b/hugo/assets/scss/components/highlight.scss
@@ -1,0 +1,13 @@
+@import '../config/colors';
+
+// Code highlight styles
+.highlight {
+    table {
+        display: block;
+        overflow-x: auto;
+
+        td:first-child {
+            border-right: 2px solid var(--pre-border-color, $c-grey-blue) !important; // To overrule hugo inline styles
+        }
+    }
+}

--- a/hugo/assets/scss/main.scss
+++ b/hugo/assets/scss/main.scss
@@ -30,6 +30,7 @@
 @import 'components/filter';
 @import 'components/footer';
 @import 'components/header';
+@import 'components/highlight';
 @import 'components/index';
 @import 'components/lastmod';
 @import 'components/link';

--- a/hugo/content/en/examples/basic/code-block/index.md
+++ b/hugo/content/en/examples/basic/code-block/index.md
@@ -54,6 +54,7 @@ You can also use syntax highlighting with Fenced Code Blocks. For this you only 
 
 [Here](https://gohugo.io/content-management/syntax-highlighting/#list-of-chroma-highlighting-languages) is a list of all the languages that can get syntax styling.
 
+You can add line numbers by adding `lineos=true`.
 You can even mark/highlight part of the code by adding `hl_lines` with the according lines you want to highlight:
 
 {{< columns >}}
@@ -79,6 +80,22 @@ You can even mark/highlight part of the code by adding `hl_lines` with the accor
 }
 ```
 {{< /columns >}}
+
+It's also possible to set `lineos=table` if you want to have table html for the line numbers:
+
+```text {title="Table", linenos=table}
+package ci
+
+import (
+	"path"
+	"encoding/yaml"
+	"tool/file"
+
+	// initialised at the start of this guide, followed by the relative path from the repository root to the `github` directory.
+	"github.com/cue-examples/github-actions-example/internal/ci/github"
+)
+
+```
 
 Other options that can be added after defining a language can be found [here](https://gohugo.io/content-management/syntax-highlighting/#highlight-shortcode).
 


### PR DESCRIPTION
- Add lineos=table to example page
- Add styling to make table fit the code-block (highlight.scss)
- Move the border of the code-block from code-block__header & pre to code-block itself because this works well with both normal code-block and table-code-block. The previous styling made overlapping borders which in some cases made the white of the table be on top of the code block border.
- Add border-right on the first td of a table inside the hightlight block so we can have a line between line numbers & code. Previous version also had a line but this line was actually caused by a bug with overlapping borders.

To test: /examples/basic/code-block/

For https://linear.app/usmedia/issue/CUE-286