### PR TITLE
Hugo: add step shortcode

### DIFF
--- a/content/docs/howto/validate-json-using-cue/en.md
+++ b/content/docs/howto/validate-json-using-cue/en.md
@@ -16,21 +16,21 @@ command line.
 
 ## Prerequisites
 
-- You have [CUE installed](https://cuelang.org/docs/install/) locally. This
-  allows you to run `cue` commands
-
-- You know how to use [CUE Definitions/ Helper Fields]({{< ref "/docs/language-guide/data" >}})
+-   You have [CUE installed](https://cuelang.org/docs/install/) locally. This
+    allows you to run `cue` commands
+-   You know how to use [CUE Definitions/ Helper Fields]({{< ref "/docs/language-guide/data" >}})
 
 ## Requirements
 
-- Using the command line or terminal
-- File editing
+-   Using the command line or terminal
+-   File editing
 
 ## Steps
 
+{{< step stepNumber="1" >}}
 Create a JSON file called `x.json` with the following:
 
-``` {title="x.json"}
+```{title="x.json"}
 {
   "people": {
     "Gopher": {
@@ -47,12 +47,15 @@ Create a JSON file called `x.json` with the following:
 }
 ```
 
+{{< /step >}}
+
+{{< step stepNumber="2" >}}
 Create a CUE file named `x.cue`
 
 The following CUE creates a CUE definition that describes the data type
 constraints for every person.
 
-``` {title="x.cue"}
+```{title="x.cue"}
 #Person: {
 	name:    string
 	age:     int
@@ -64,6 +67,9 @@ people: [X=string]: #Person & {
 }
 ```
 
+{{< /step >}}
+
+{{< step stepNumber="3" >}}
 Run the following `cue` command in your terminal:
 
 ```console
@@ -71,11 +77,13 @@ $ cue vet x.cue x.json
 ```
 
 _NOTE: `cue vet` is silent when run successfully. Output will only show on error._
+{{< /step >}}
 
+{{< step stepNumber="4" >}}
 Add another person to your JSON data by replacing your `x.json` file with the
 following:
 
-``` {title="x.json"}
+```{title="x.json"}
 {
   "people": {
     "Gopher": {
@@ -97,6 +105,9 @@ following:
 }
 ```
 
+{{< /step >}}
+
+{{< step stepNumber="5" >}}
 Validate again with `cue vet`:
 
 ```console
@@ -109,10 +120,12 @@ people.Rob.age: conflicting values 42.2 and int (mismatched types float and int)
 
 The command output shows validation errors where the JSON violates
 the (type) constraints that you have declared.
+{{< /step >}}
 
+{{< step stepNumber="6" >}}
 Fix up the JSON:
 
-``` {title="x.json"}
+```{title="x.json"}
 {
   "people": {
     "Gopher": {
@@ -134,6 +147,9 @@ Fix up the JSON:
 }
 ```
 
+{{< /step >}}
+
+{{< step stepNumber="7" >}}
 Validate with `cue vet` again
 
 ```console
@@ -141,6 +157,7 @@ $ cue vet x.cue x.json
 ```
 
 The `cue vet` command will show no output on success.
+{{< /step >}}
 
 Well done! Any future data errors on names, ages, and addresses in your JSON
 will be detected. This is especially helpful with JSON files with 100s (and
@@ -148,4 +165,4 @@ even 1000s) of lines.
 
 #### Further reading/See Also
 
-- [cmd/cue command line documentation](https://cue.googlesource.com/cue/+/refs/tags/v0.2.0/doc/cmd/cue.md)
+-   [cmd/cue command line documentation](https://cue.googlesource.com/cue/+/refs/tags/v0.2.0/doc/cmd/cue.md)

--- a/content/examples/_en.html
+++ b/content/examples/_en.html
@@ -133,6 +133,11 @@ description: "View examples on how to use certain possible elements of the theme
                             </a>
                         </li>
                         <li class="nav__item">
+                            <a class="nav__link" href="/examples/shortcodes/step/">
+                                <span class="nav__text">Step</span>
+                            </a>
+                        </li>
+                        <li class="nav__item">
                             <a class="nav__link" href="/examples/shortcodes/table/">
                                 <span class="nav__text">Table</span>
                             </a>

--- a/content/examples/shortcodes/step/en.md
+++ b/content/examples/shortcodes/step/en.md
@@ -1,0 +1,110 @@
+---
+title: Step
+weight: 31
+---
+
+With the step shortcode you can add for example a step-by-step walkthrough.
+
+## Attributes
+
+stepNumber
+: required - add the number for the step. Without this, no step number will be shown/
+
+group
+: optional - if you want to use multiple step series, add a groupname per series.
+This adds the groupname to the id, which makes it possible to link to the steps.
+
+## Examples
+
+Below, you can find two example step lists. Click on the numbers to see the url change.
+Here you can also see the use of the group name.
+
+### Step group example
+
+````
+{{</* step group="example" stepNumber="1" */>}}
+Open a command prompt and create a new directory to hold this tutorial's files.
+For example:
+
+    ```
+    {
+        "firstName": "John",
+        "lastName": "Smith",
+        "age": 25
+    }
+    ```
+
+{{</* /step */>}}
+
+{{</* step group="example" stepNumber="2" */>}}
+Create a data file named `charlie.yml` to hold Charlie the cat's details.
+Place this information in it, including the deliberate mistake in the `species`
+{{</* /step */>}}
+
+````
+
+Results in the following steps:
+
+{{< step group="example" stepNumber="1" >}}
+Open a command prompt and create a new directory to hold this tutorial's files.
+For example:
+
+```
+{
+    "firstName": "John",
+    "lastName": "Smith",
+    "age": 25
+}
+```
+
+{{< /step >}}
+
+{{< step group="example" stepNumber="2" >}}
+Create a data file named `charlie.yml` to hold Charlie the cat's details.
+Place this information in it, including the deliberate mistake in the `species`
+{{< /step >}}
+
+### Other step group example
+
+````
+{{</* step group="other" stepNumber="1" */>}}
+Open a command prompt and create a new directory to hold this tutorial's files.
+For example:
+
+    ```
+    {
+        "firstName": "John",
+        "lastName": "Smith",
+        "age": 25
+    }
+    ```
+
+{{</* /step */>}}
+
+{{</* step group="other" stepNumber="2" */>}}
+Create a data file named `charlie.yml` to hold Charlie the cat's details.
+Place this information in it, including the deliberate mistake in the `species`
+{{</* /step */>}}
+
+````
+
+Results in the following steps:
+
+{{< step group="other" stepNumber="1" >}}
+Open a command prompt and create a new directory to hold this tutorial's files.
+For example:
+
+```
+{
+    "firstName": "John",
+    "lastName": "Smith",
+    "age": 25
+}
+```
+
+{{< /step >}}
+
+{{< step group="other" stepNumber="2" >}}
+Create a data file named `charlie.yml` to hold Charlie the cat's details.
+Place this information in it, including the deliberate mistake in the `species`
+{{< /step >}}

--- a/content/examples/shortcodes/step/page.cue
+++ b/content/examples/shortcodes/step/page.cue
@@ -1,0 +1,3 @@
+package site
+
+"examples": "shortcodes": "step": {}

--- a/hugo/assets/scss/components/step.scss
+++ b/hugo/assets/scss/components/step.scss
@@ -1,0 +1,48 @@
+@import '../config/colors';
+@import '../config/sizes';
+@import '../config/typography';
+@import '../mixins/screen';
+
+.step {
+    $self: &;
+
+    align-items: flex-start;
+    border-bottom: 1px solid $c-lavender--light;
+    display: flex;
+    flex-direction: column;
+    gap: $p-gutter * 0.5;
+    padding: $p-gutter 0;
+
+    & + p {
+        margin-top: 2rem;
+    }
+
+    &__number {
+        --button-height: 34px;
+
+        align-items: center;
+        border-radius: $b-radius--round;
+        display: flex;
+        flex: 0 0 var(--button-height);
+        font-size: 1.25rem;
+        justify-content: center;
+    }
+
+    &__content {
+        width: 100%;
+
+        > :last-child {
+            margin-bottom: 0;
+        }
+    }
+
+    @include screen($screen-normal) {
+        flex-direction: row;
+        gap: $p-gutter;
+        padding: $p-gutter--large 0;
+
+        p + & {
+            padding-top: $p-gutter;
+        }
+    }
+}

--- a/hugo/assets/scss/main.scss
+++ b/hugo/assets/scss/main.scss
@@ -51,6 +51,7 @@
 @import 'components/separator';
 @import 'components/sidenote';
 @import 'components/spinner';
+@import 'components/step';
 @import 'components/tabs';
 @import 'components/tabs-nav';
 @import 'components/table';

--- a/hugo/content/en/docs/howto/validate-json-using-cue/index.md
+++ b/hugo/content/en/docs/howto/validate-json-using-cue/index.md
@@ -16,21 +16,21 @@ command line.
 
 ## Prerequisites
 
-- You have [CUE installed](https://cuelang.org/docs/install/) locally. This
-  allows you to run `cue` commands
-
-- You know how to use [CUE Definitions/ Helper Fields]({{< ref "/docs/language-guide/data" >}})
+-   You have [CUE installed](https://cuelang.org/docs/install/) locally. This
+    allows you to run `cue` commands
+-   You know how to use [CUE Definitions/ Helper Fields]({{< ref "/docs/language-guide/data" >}})
 
 ## Requirements
 
-- Using the command line or terminal
-- File editing
+-   Using the command line or terminal
+-   File editing
 
 ## Steps
 
+{{< step stepNumber="1" >}}
 Create a JSON file called `x.json` with the following:
 
-``` {title="x.json"}
+```{title="x.json"}
 {
   "people": {
     "Gopher": {
@@ -47,12 +47,15 @@ Create a JSON file called `x.json` with the following:
 }
 ```
 
+{{< /step >}}
+
+{{< step stepNumber="2" >}}
 Create a CUE file named `x.cue`
 
 The following CUE creates a CUE definition that describes the data type
 constraints for every person.
 
-``` {title="x.cue"}
+```{title="x.cue"}
 #Person: {
 	name:    string
 	age:     int
@@ -64,6 +67,9 @@ people: [X=string]: #Person & {
 }
 ```
 
+{{< /step >}}
+
+{{< step stepNumber="3" >}}
 Run the following `cue` command in your terminal:
 
 ```console
@@ -71,11 +77,13 @@ $ cue vet x.cue x.json
 ```
 
 _NOTE: `cue vet` is silent when run successfully. Output will only show on error._
+{{< /step >}}
 
+{{< step stepNumber="4" >}}
 Add another person to your JSON data by replacing your `x.json` file with the
 following:
 
-``` {title="x.json"}
+```{title="x.json"}
 {
   "people": {
     "Gopher": {
@@ -97,6 +105,9 @@ following:
 }
 ```
 
+{{< /step >}}
+
+{{< step stepNumber="5" >}}
 Validate again with `cue vet`:
 
 ```console
@@ -109,10 +120,12 @@ people.Rob.age: conflicting values 42.2 and int (mismatched types float and int)
 
 The command output shows validation errors where the JSON violates
 the (type) constraints that you have declared.
+{{< /step >}}
 
+{{< step stepNumber="6" >}}
 Fix up the JSON:
 
-``` {title="x.json"}
+```{title="x.json"}
 {
   "people": {
     "Gopher": {
@@ -134,6 +147,9 @@ Fix up the JSON:
 }
 ```
 
+{{< /step >}}
+
+{{< step stepNumber="7" >}}
 Validate with `cue vet` again
 
 ```console
@@ -141,6 +157,7 @@ $ cue vet x.cue x.json
 ```
 
 The `cue vet` command will show no output on success.
+{{< /step >}}
 
 Well done! Any future data errors on names, ages, and addresses in your JSON
 will be detected. This is especially helpful with JSON files with 100s (and
@@ -148,4 +165,4 @@ even 1000s) of lines.
 
 #### Further reading/See Also
 
-- [cmd/cue command line documentation](https://cue.googlesource.com/cue/+/refs/tags/v0.2.0/doc/cmd/cue.md)
+-   [cmd/cue command line documentation](https://cue.googlesource.com/cue/+/refs/tags/v0.2.0/doc/cmd/cue.md)

--- a/hugo/content/en/examples/_index.html
+++ b/hugo/content/en/examples/_index.html
@@ -133,6 +133,11 @@ description: "View examples on how to use certain possible elements of the theme
                             </a>
                         </li>
                         <li class="nav__item">
+                            <a class="nav__link" href="/examples/shortcodes/step/">
+                                <span class="nav__text">Step</span>
+                            </a>
+                        </li>
+                        <li class="nav__item">
                             <a class="nav__link" href="/examples/shortcodes/table/">
                                 <span class="nav__text">Table</span>
                             </a>

--- a/hugo/content/en/examples/shortcodes/step/index.md
+++ b/hugo/content/en/examples/shortcodes/step/index.md
@@ -1,0 +1,110 @@
+---
+title: Step
+weight: 31
+---
+
+With the step shortcode you can add for example a step-by-step walkthrough.
+
+## Attributes
+
+stepNumber
+: required - add the number for the step. Without this, no step number will be shown/
+
+group
+: optional - if you want to use multiple step series, add a groupname per series.
+This adds the groupname to the id, which makes it possible to link to the steps.
+
+## Examples
+
+Below, you can find two example step lists. Click on the numbers to see the url change.
+Here you can also see the use of the group name.
+
+### Step group example
+
+````
+{{</* step group="example" stepNumber="1" */>}}
+Open a command prompt and create a new directory to hold this tutorial's files.
+For example:
+
+    ```
+    {
+        "firstName": "John",
+        "lastName": "Smith",
+        "age": 25
+    }
+    ```
+
+{{</* /step */>}}
+
+{{</* step group="example" stepNumber="2" */>}}
+Create a data file named `charlie.yml` to hold Charlie the cat's details.
+Place this information in it, including the deliberate mistake in the `species`
+{{</* /step */>}}
+
+````
+
+Results in the following steps:
+
+{{< step group="example" stepNumber="1" >}}
+Open a command prompt and create a new directory to hold this tutorial's files.
+For example:
+
+```
+{
+    "firstName": "John",
+    "lastName": "Smith",
+    "age": 25
+}
+```
+
+{{< /step >}}
+
+{{< step group="example" stepNumber="2" >}}
+Create a data file named `charlie.yml` to hold Charlie the cat's details.
+Place this information in it, including the deliberate mistake in the `species`
+{{< /step >}}
+
+### Other step group example
+
+````
+{{</* step group="other" stepNumber="1" */>}}
+Open a command prompt and create a new directory to hold this tutorial's files.
+For example:
+
+    ```
+    {
+        "firstName": "John",
+        "lastName": "Smith",
+        "age": 25
+    }
+    ```
+
+{{</* /step */>}}
+
+{{</* step group="other" stepNumber="2" */>}}
+Create a data file named `charlie.yml` to hold Charlie the cat's details.
+Place this information in it, including the deliberate mistake in the `species`
+{{</* /step */>}}
+
+````
+
+Results in the following steps:
+
+{{< step group="other" stepNumber="1" >}}
+Open a command prompt and create a new directory to hold this tutorial's files.
+For example:
+
+```
+{
+    "firstName": "John",
+    "lastName": "Smith",
+    "age": 25
+}
+```
+
+{{< /step >}}
+
+{{< step group="other" stepNumber="2" >}}
+Create a data file named `charlie.yml` to hold Charlie the cat's details.
+Place this information in it, including the deliberate mistake in the `species`
+{{< /step >}}

--- a/hugo/layouts/_default/_markup/render-codeblock.html
+++ b/hugo/layouts/_default/_markup/render-codeblock.html
@@ -4,8 +4,8 @@
 {{- $showCopyButton := ne (index .Attributes "codetocopy") false -}}
 {{- $codeToCopy := index .Attributes "codetocopy" | default (.Inner | base64Encode) -}}
 
-<div class="code-block{{ if $title }} code-block--heading{{ end }}{{ if eq $type "terminal" }} code-block--terminal{{ end }}
-{{ if $modifier }} {{ $modifier}}{{ end }}"{{- if $showCopyButton -}} data-copy{{- end -}}>
+<div class="code-block{{ if $title }} code-block--heading{{ end }}{{ if eq $type "terminal" }} code-block--terminal{{ end }}{{ if $modifier }} {{ $modifier}}{{ end }}"
+{{- if $showCopyButton -}} data-copy{{- end -}}>
     {{- with $title -}}
         <div class="code-block__heading">
             <span class="code-block__tab">{{- . -}}</span>

--- a/hugo/layouts/shortcodes/step.html
+++ b/hugo/layouts/shortcodes/step.html
@@ -1,0 +1,19 @@
+{{ $stepNumber := .Get "stepNumber" | default false}}
+{{ $group := .Get "group" | default false }}
+{{ $id := cond (ne $group false) (print $group "-step-" $stepNumber) (print "step-" $stepNumber) }}
+
+<div class="step" id="{{ $id }}" data-step-group="{{ $group }}">
+    {{ if $stepNumber }}
+        <a class="button button--icon button--yellow step__number" href="#{{ $id }}" data-step-number="{{ $stepNumber }}">
+            {{- $stepNumber -}}
+        </a>
+    {{ end }}
+
+    <div class="step__content">
+        {{ if eq .Page.File.Ext "md" }}
+            {{ .Inner | markdownify }}
+        {{ else }}
+            {{ .Inner | htmlUnescape | safeHTML }}
+        {{ end }}
+    </div>
+</div>


### PR DESCRIPTION
- Add html for steps
- Add example page for step shortcode (/examples/shortcodes/step)
- Add example to docs page (/docs/howto/validate-json-using-cue/)
- Fix codeblock classes: remove excess whitespace

For https://linear.app/usmedia/issue/CUE-285