### PR TITLE
Hugo: new search results styling

### DIFF
--- a/hugo/algolia-settings.js
+++ b/hugo/algolia-settings.js
@@ -24,9 +24,9 @@ index.setSettings({
     attributesForFaceting: ['tags', 'contentType'],
     distinct: true,
     attributeForDistinct: 'link',
-    highlightPreTag: '<mark>',
-    highlightPostTag: '</mark>',
-    attributesToSnippet: ['summary'],
+    highlightPreTag: '<strong>',
+    highlightPostTag: '</strong>',
+    attributesToSnippet: ['summary:30'],
     attributesToHighlight: ['title', 'summary', 'content'],
 }).then(() => {
     console.log('Updating Algolia Settings successful');

--- a/hugo/assets/scss/components/list.scss
+++ b/hugo/assets/scss/components/list.scss
@@ -37,6 +37,10 @@
         display: flex;
         flex-wrap: wrap;
         gap: 7px;
+
+        #{ $self }__item {
+            border-bottom: 0;
+        }
     }
 
     @include screen($screen-simple) {

--- a/hugo/assets/scss/components/searchbar.scss
+++ b/hugo/assets/scss/components/searchbar.scss
@@ -86,15 +86,31 @@
         text-decoration: none;
     }
 
+    &__breadcrumb {
+        @include style-text-small;
+
+        color: var(--searchbar-breadcrumb-color, $c-blue--darker);
+
+        span {
+            &::after {
+                content: ' / ';
+            }
+        }
+    }
+
     &__item-title {
         @include style-heading-4;
 
-        margin: 0;
+        color: var(--searchbar-title-color, $c-blue--light);
+        margin: 0.25rem 0;
     }
 
     &__item-description {
+        @include style-text-small;
+
+        color: var(--searchbar-description-color, $c-grey-blue--dark);
         line-height: 1.75;
-        margin: 10px 0 0;
+        margin: 0;
 
         &:empty {
             margin: 0;

--- a/hugo/assets/scss/components/tag.scss
+++ b/hugo/assets/scss/components/tag.scss
@@ -2,10 +2,8 @@
 @import '../config/typography';
 
 .tag {
-    --tag-background: #{ $c-blue--lighter };
-
     align-items: center;
-    background: var(--tag-background);
+    background: var(--tag-background, $c-blue--lighter);
     border-radius: 1.5rem;
     color: $c-black;
     display: flex;

--- a/hugo/assets/scss/components/teaser.scss
+++ b/hugo/assets/scss/components/teaser.scss
@@ -23,16 +23,26 @@
         }
     }
 
+    &__breadcrumb {
+        @include style-text-small;
+
+        color: var(--teaser-breadcrumb-color, $c-blue--darker);
+
+        span {
+            &:last-child {
+                &::after {
+                    content: ' /';
+                }
+            }
+        }
+    }
+
     &__title {
         @include style-heading;
 
-        color: $c-blue--dark;
-        font-size: 1.5rem;
-        margin: 0 0 0.4rem;
-    }
-
-    &__tags {
-        z-index: 1;
+        color: var(--teaser-title-color, $c-blue--light);
+        font-size: 1.375rem;
+        margin: 0.5rem 0 0;
     }
 
     &__meta {
@@ -43,8 +53,17 @@
     }
 
     &__excerpt {
-        font-weight: $weight-medium;
+        @include style-text-small;
+
+        color: var(--teaser-excerpt-color, $c-grey-blue--dark);
         margin: 0.5rem 0 0;
+    }
+
+    &__tags {
+        --tag-background: #{ $c-white };
+
+        margin-top: 0.5rem;
+        z-index: 1;
     }
 
     &__link {
@@ -54,9 +73,11 @@
         border-radius: $b-radius;
         transition: border-color 0.2s, background-color 0.2s;
 
+        /* stylelint-disable no-descending-specificity */
         span {
             @include sr-only;
         }
+        /* stylelint-enable no-descending-specificity */
 
         &:focus,
         &:hover {
@@ -113,7 +134,14 @@
     }
 
     @include screen($screen-simple) {
-        padding: 1.5rem;
+        padding: $p-gutter 1.5rem;
+
+        &__heading {
+            align-items: flex-start;
+            display: flex;
+            flex-wrap: wrap;
+            gap: 1rem;
+        }
 
         &--blog {
             padding: 0;
@@ -153,18 +181,6 @@
                     font-size: 2rem;
                 }
             }
-
-        }
-
-        &__heading {
-            align-items: flex-start;
-            display: flex;
-            flex-wrap: wrap;
-            gap: 1rem;
-        }
-
-        &__tags {
-            margin-top: 4px;
         }
     }
 

--- a/hugo/assets/ts/interfaces/search.ts
+++ b/hugo/assets/ts/interfaces/search.ts
@@ -5,6 +5,7 @@ export interface SearchItem {
     summary: string;
     publishDate: string;
     content: string;
+    breadcrumb: string[];
     contentType: string;
     tags: string | string[];
 }

--- a/hugo/assets/ts/interfaces/teaser.ts
+++ b/hugo/assets/ts/interfaces/teaser.ts
@@ -2,6 +2,6 @@ export interface Teaser {
     title: string;
     link: string;
     summary: string;
-    contentType: string;
+    breadcrumb: string[];
     tags: string[];
 }

--- a/hugo/assets/ts/widgets/search-autocomplete.ts
+++ b/hugo/assets/ts/widgets/search-autocomplete.ts
@@ -9,6 +9,7 @@ import { AutocompleteApi } from '@algolia/autocomplete-js/dist/esm/types';
 import { BaseItem, OnSubmitParams } from '@algolia/autocomplete-shared/dist/esm/core';
 import { BaseWidget } from './base-widget';
 import { mapToAlgoliaFilters, parseQuery } from '../helpers/search';
+import { SearchItem } from '../interfaces/search';
 
 export class SearchAutocomplete extends BaseWidget {
     public static readonly NAME = 'search-autocomplete';
@@ -136,7 +137,7 @@ export class SearchAutocomplete extends BaseWidget {
                                 query: parsedQuery.cleanQuery,
                                 params: {
                                     hitsPerPage: 5,
-                                    attributesToSnippet: ['title:6', 'summary:25'],
+                                    attributesToSnippet: ['title:6', 'summary:30'],
                                     snippetEllipsisText: '…',
                                     filters: filters,
                                 },
@@ -153,7 +154,7 @@ export class SearchAutocomplete extends BaseWidget {
                                 <div class="aa-SourceHeaderLine searchbar__header-line"></div>
                             `;
                         },
-                        item({ item, components, html }) {
+                        item({ item, html }) {
                             function htmlDecode(input: string, length = 100) {
                                 const doc = new DOMParser().parseFromString(input, 'text/html');
                                 const content = doc.documentElement.textContent;
@@ -168,11 +169,16 @@ export class SearchAutocomplete extends BaseWidget {
                             return html`
                                 <a class="searchbar__item" href="${ item.link }">
                                     <div class="searchbar__item-content">
+                                        ${ ((item.breadcrumb as SearchItem['breadcrumb']) && (item.breadcrumb as SearchItem['breadcrumb']).length >= 0) ? html`
+                                            <div class="searchbar__breadcrumb">
+                                                ${ (item.breadcrumb as SearchItem['breadcrumb']).map((breadcrumb: string) => html`
+                                                    <span>${ breadcrumb }</span>
+                                                `) }
+                                            </div>
+                                        ` : '' }
+
                                         <h2 class="searchbar__item-title">
-                                            ${ components.Highlight({
-                                                hit: item,
-                                                attribute: 'title',
-                                            }) }
+                                            ${ htmlDecode(item.title.toString()) }
                                         </h2>
 
                                         <p class="searchbar__item-description">

--- a/hugo/assets/ts/widgets/search-results.ts
+++ b/hugo/assets/ts/widgets/search-results.ts
@@ -85,10 +85,10 @@ export class SearchResults extends BaseWidget {
 
     public mapSearchHitToTeaser(hit: Hit<SearchItem>): Teaser {
         return {
-            title: hit._highlightResult.title.value,
+            title: hit.title,
             link: hit.link,
             summary: hit._snippetResult.summary.value,
-            contentType: hit.contentType,
+            breadcrumb: hit.breadcrumb,
             tags: (Array.isArray(hit.tags) ? hit.tags : [hit.tags]).filter(tag => tag),
         };
     }
@@ -102,15 +102,18 @@ export class SearchResults extends BaseWidget {
         return `
             <li class="list__item">
                 <div class="teaser">
+                    ${ (teaser.breadcrumb && teaser.breadcrumb.length > 0) ? `<div class="teaser__breadcrumb">
+                        ${ teaser.breadcrumb.map(breadcrumb => `<span>${ breadcrumb }</span>`).join(' / ') }
+                    </div>` : '' }
                     <div class="teaser__heading">
                         <h2 class="teaser__title">${ teaser.title }</h2>
-                        ${ (tags && tags.length) ? `<ul class="list list--tags teaser__tags">
-                            ${ tags.map(tag => `<li class="list__item">
-                                <button class="tag tag--${ tag.color }" data-value="${ tag.name }">${ tag.name }</button></li>`) }
-                        </ul>` : '' }
                     </div>
-                    ${ (teaser.contentType) ? `<p class="teaser__meta">${ teaser.contentType }</p>` : '' }
                     ${ (teaser.summary) ? `<div class="teaser__excerpt">${ teaser.summary }</div>` : '' }
+                    ${ (tags && tags.length) ? `<ul class="list list--tags teaser__tags">
+                        ${ tags.map(tag => `<li class="list__item">
+                            <button class="tag tag--${ tag.color }" data-value="${ tag.name }">${ tag.name }</button>
+                        </li>`).join('') }
+                    </ul>` : '' }
                     <a class="teaser__link" href="${ teaser.link }">
                         <span>Read more</span>
                     </a>

--- a/hugo/layouts/_default/list.algolia.json
+++ b/hugo/layouts/_default/list.algolia.json
@@ -31,6 +31,7 @@
     {{- $content := "" -}}
     {{- $tags := cond (isset $page.Params "tags") ($page.Params.tags) "" -}}
     {{- $contentType := $page.FirstSection.Title -}}
+    {{- $breadcrumb := slice -}}
 
     {{/* If section is docs we derive the content type from the first level of nesting within docs*/}}
     {{- if and (eq $page.Section "docs") (ne $page $page.FirstSection) -}}
@@ -49,6 +50,14 @@
         {{- end -}}
     {{- end -}}
 
+    {{- if ne $page $page.FirstSection -}}
+        {{- range $index, $parent := $page.Ancestors.Reverse -}}
+            {{- if eq .IsHome false -}}
+                {{- $breadcrumb = $breadcrumb | append $parent.Title -}}
+            {{ end }}
+        {{- end -}}
+    {{- end -}}
+
     {{- if eq $index 0 -}}
         {{- $content = delimit (first $cutoff $page.PlainWords) " " -}}
     {{- else -}}
@@ -62,6 +71,7 @@
         "publishDate": {{ $publishDate | jsonify }},
         "summary": {{ $summary | jsonify }},
         "content": {{ $content  | jsonify}},
+        "breadcrumb": {{ $breadcrumb | jsonify }},
         "contentType": {{ $contentType | jsonify }},
         "tags": {{ $tags | jsonify }}
     }

--- a/hugo/layouts/_default/search.html
+++ b/hugo/layouts/_default/search.html
@@ -22,7 +22,7 @@
         <div class="section__body">
             <div class="section__content" data-search-results data-tags="{{ .Site.Params.tags | jsonify }}">
                 <div class="search">
-                    <div class="search__ bar">
+                    <div class="search__bar">
                         {{- partial "searchbar.html" (dict
                             "type" "results"
                             "inputId" "searchbar"


### PR DESCRIPTION
- Added breadcrumb to algolia.json
- Added the breadcrumb to the search result teasers
- Adjusted the styling according to design
- Adjusted Algolia settings: 
    - use `<strong>` in stead of `<mark>` for highlighting 
    - cut summary after 30 words in stead of 10

For testing:
1. create a new test index in Algolia (see hugo > readme for a walkthrough)
2. (temporarily) replace the index names with your new index name
3. look at the search results, both the search widget as on the /search page

For testing the styling changes:
- For example, search for `JSON` or `blog` on the search page
- For example, search for `JSON` or `blog` in the search widget

![Screenshot 2023-08-29 at 17 16 10](https://github.com/cue-lang/cuelang.org/assets/122522301/41247101-161a-4e92-9bec-db099cc618e6)

For https://linear.app/usmedia/issue/CUE-290