### PR TITLE
hugo: Exclude examples and pages with attr noindex from search/sitemap

### DIFF
--- a/content/blog/example/en.md
+++ b/content/blog/example/en.md
@@ -2,6 +2,7 @@
 title: Example blog page and also a longer title
 date: "2023-04-06"
 draft: false
+noindex: true
 image: "cow.jpg"
 authors:
     - pauljolly

--- a/content/blog/example2/en.md
+++ b/content/blog/example2/en.md
@@ -2,6 +2,7 @@
 title: Example blog page 2 with a longer title
 date: "2023-01-01"
 draft: false
+noindex: true
 image: "allium.jpg"
 ---
 

--- a/content/blog/example3/en.md
+++ b/content/blog/example3/en.md
@@ -2,6 +2,7 @@
 title: Example blog page 3
 date: "2023-03-10"
 draft: false
+noindex: true
 image: "moon.jpg"
 ---
 

--- a/content/blog/example4/en.md
+++ b/content/blog/example4/en.md
@@ -2,6 +2,7 @@
 title: Example blog page 4
 date: "2023-03-10"
 draft: false
+noindex: true
 image: "birds.jpg"
 ---
 

--- a/content/examples/basic/front-matter/en.md
+++ b/content/examples/basic/front-matter/en.md
@@ -60,11 +60,12 @@ meta:
 
 notification
 : You can add a sticky notification on the current page. The `content` allows for simple markdown options.
+
 ```
 notification:
     content: '**Note:** a sticky note we wanted to show at the bottom'
-
 ```
+
 Additionally you can add a button to the notification (the icon param is optional).
 ```
 notification:
@@ -86,3 +87,6 @@ tags:
 
 authors
 : adding the author(s) to the frontmatter, makes the content header show an image + name of the assigned author. It also shows a popup on click, with again an image + (display) name, and when available a link to their Github, and a link to the search page so users can search for other articles of this author.
+
+noindex
+: adding noindex: true to the front-matter add the meta tag `<meta name="robots" content="noindex, nofollow">` to the head of the page. Also the pages will be excluded from the sitemap.xml.

--- a/hugo/content/en/blog/example/index.md
+++ b/hugo/content/en/blog/example/index.md
@@ -2,6 +2,7 @@
 title: Example blog page and also a longer title
 date: "2023-04-06"
 draft: false
+noindex: true
 image: "cow.jpg"
 authors:
     - pauljolly

--- a/hugo/content/en/blog/example2/index.md
+++ b/hugo/content/en/blog/example2/index.md
@@ -2,6 +2,7 @@
 title: Example blog page 2 with a longer title
 date: "2023-01-01"
 draft: false
+noindex: true
 image: "allium.jpg"
 ---
 

--- a/hugo/content/en/blog/example3/index.md
+++ b/hugo/content/en/blog/example3/index.md
@@ -2,6 +2,7 @@
 title: Example blog page 3
 date: "2023-03-10"
 draft: false
+noindex: true
 image: "moon.jpg"
 ---
 

--- a/hugo/content/en/blog/example4/index.md
+++ b/hugo/content/en/blog/example4/index.md
@@ -2,6 +2,7 @@
 title: Example blog page 4
 date: "2023-03-10"
 draft: false
+noindex: true
 image: "birds.jpg"
 ---
 

--- a/hugo/content/en/examples/basic/front-matter/index.md
+++ b/hugo/content/en/examples/basic/front-matter/index.md
@@ -60,11 +60,12 @@ meta:
 
 notification
 : You can add a sticky notification on the current page. The `content` allows for simple markdown options.
+
 ```
 notification:
     content: '**Note:** a sticky note we wanted to show at the bottom'
-
 ```
+
 Additionally you can add a button to the notification (the icon param is optional).
 ```
 notification:
@@ -86,3 +87,6 @@ tags:
 
 authors
 : adding the author(s) to the frontmatter, makes the content header show an image + name of the assigned author. It also shows a popup on click, with again an image + (display) name, and when available a link to their Github, and a link to the search page so users can search for other articles of this author.
+
+noindex
+: adding noindex: true to the front-matter add the meta tag `<meta name="robots" content="noindex, nofollow">` to the head of the page. Also the pages will be excluded from the sitemap.xml.

--- a/hugo/layouts/_default/sitemap.xml
+++ b/hugo/layouts/_default/sitemap.xml
@@ -1,0 +1,33 @@
+{{ printf "<?xml version=\"1.0\" encoding=\"utf-8\" standalone=\"yes\"?>" | safeHTML }}
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9" xmlns:xhtml="http://www.w3.org/1999/xhtml">
+    {{ range where (where .Data.Pages "Type" "!=" "examples") "Params.noindex" "ne" true }}
+        {{- if .Permalink -}}
+            <url>
+                <loc>{{ .Permalink }}</loc>
+                {{- if not .Lastmod.IsZero }}
+                    <lastmod>{{ safeHTML ( .Lastmod.Format "2006-01-02T15:04:05-07:00" ) }}</lastmod>
+                {{- end -}}
+                {{- with .Sitemap.ChangeFreq }}
+                    <changefreq>{{ . }}</changefreq>
+                {{ end }}
+                {{- if ge .Sitemap.Priority 0.0 -}}
+                    <priority>{{ .Sitemap.Priority }}</priority>
+                {{- end -}}
+                {{- if .IsTranslated -}}
+                    {{ range .Translations }}
+                        <xhtml:link
+                            rel="alternate"
+                            hreflang="{{ .Language.LanguageCode }}"
+                            href="{{ .Permalink }}"
+                        />
+                    {{- end -}}
+                    <xhtml:link
+                        rel="alternate"
+                        hreflang="{{ .Language.LanguageCode }}"
+                        href="{{ .Permalink }}"
+                    />
+                {{- end -}}
+            </url>
+        {{- end -}}
+    {{- end -}}
+</urlset>

--- a/hugo/layouts/partials/site/head.html
+++ b/hugo/layouts/partials/site/head.html
@@ -5,13 +5,13 @@
 {{ else }}{{ with .Site.Params.description -}}{{- . | $.RenderString | plainify -}}
 {{ end }}{{ end }}{{ end -}}">
 {{ hugo.Generator }}
-{{ if eq (getenv "HUGO_ENV") "production" }}
+{{ if and (eq (getenv "HUGO_ENV") "production") (ne .Params.noindex true) (ne .Type "examples") }}
 <meta name="robots" content="index, follow">
 {{ else }}
 <meta name="robots" content="noindex, nofollow">
 {{ end }}
 {{ range .AlternativeOutputFormats -}}
-<link rel="{{ .Rel }}" type="{{ .MediaType.Type }}" href="{{ .RelPermalink | safeURL }}">
+    <link rel="{{ .Rel }}" type="{{ .MediaType.Type }}" href="{{ .RelPermalink | safeURL }}">
 {{ end -}}
 {{ partialCached "site/favicons.html" . }}
 <title>{{ if .IsHome }}{{ .Site.Title }}{{ else }}{{ with .Title }}{{ . }} | {{ end }}{{ .Site.Title }}{{ end }}</title>
@@ -19,8 +19,9 @@
 {{- template "_internal/schema.html" . -}}
 {{- template "_internal/twitter_cards.html" . -}}
 {{ if eq (getenv "HUGO_ENV") "production" }}
-{{ template "_internal/google_analytics_async.html" . }}
+    {{ template "_internal/google_analytics_async.html" . }}
 {{ end }}
 {{ partialCached "site/css.html" . }}
 {{ $jsHead := (resources.Get "ts/head.ts" | js.Build) }}
-{{ with resources.Get "ts/head.ts" }}<script>{{ ( . | js.Build | minify ).Content | safeJS }}</script>{{ end }}
+{{ with resources.Get "ts/head.ts" }}
+<script>{{ ( . | js.Build | minify ).Content | safeJS }}</script>{{ end }}


### PR DESCRIPTION
- Add no-robots meta tag to pages from content type "Examples" and pages where the front-matter param 'noindex' is set to true
- Add custom rendering of sitemap.xml: copied code from hugo internals and add a where clause to make it only add pages to the sitemap which are not of content type "examples" and don't have param noindex set to true
- Add noindex example to the example page of the front-matter
- Fix issue in front-mattter example md where code block was not closed correctly

To test:
- Go to  /sitemap.xml Example pages are not included here. Also example blogs are not included here because of the front-matter param noindex: true

- Go to /blogs/example and use 'inspect' or 'view page source' in your browser tools. You see the meta tag `<meta name="robots" content="noindex, nofollow">` in the `<head>` html. The sames goes for all examples/* pages.

- All other pages should have `<meta name="robots" content="index, follow">`


 For https://linear.app/usmedia/issue/CUE-299