### PR TITLE
Hugo: finetune blog teaser styling (/blog/)

### DIFF
--- a/hugo/assets/scss/components/teaser.scss
+++ b/hugo/assets/scss/components/teaser.scss
@@ -90,13 +90,58 @@
     }
 
     &--blog {
+        --teaser-title-color: #{ $c-blue--darker };
+        --teaser-excerpt-color: #{ $c-blue--darker };
+
         padding: 0;
+
+        #{ $self }__title,
+        #{ $self }__meta,
+        #{ $self }__excerpt {
+            margin: 0;
+        }
+
+        #{ $self }__image {
+            aspect-ratio: 16 / 9;
+            overflow: hidden;
+            position: relative;
+            width: 100%;
+
+            img {
+                @include stretch;
+
+                object-fit: cover;
+                transition: transform 0.3s ease-in-out;
+            }
+        }
+
+        #{ $self }__title {
+            @include style-heading-3;
+        }
+
+        #{ $self }__date {
+            margin: 0;
+        }
+
+        #{ $self }__tags {
+            margin-top: 1rem;
+        }
 
         #{ $self }__content {
             display: flex;
             flex-direction: column;
-            gap: 14px;
-            padding: 8px;
+            gap: 1rem;
+            padding: 1rem 0;
+        }
+
+        #{ $self }__excerpt {
+            @include style-text;
+        }
+
+        #{ $self }__readmore {
+            color: var(--teaser-readmore-color, $c-blue--darker);
+            height: 100%;
+            padding: 0;
         }
 
         #{ $self }__link {
@@ -104,32 +149,6 @@
             &:hover {
                 background: var(--teaser-background, transparent);
             }
-        }
-
-        #{ $self }__meta,
-        #{ $self }__excerpt,
-        #{ $self }__title {
-            margin: 0;
-        }
-
-        #{ $self }__title {
-            @include style-heading-3;
-        }
-
-        #{ $self }__image {
-            height: 164px;
-            margin: 0 0 12px;
-            overflow: hidden;
-
-            img {
-                height: 100%;
-                object-fit: cover;
-                transition: transform 0.4s;
-            }
-        }
-
-        .link {
-            padding: 0;
         }
     }
 
@@ -154,31 +173,28 @@
                 }
             }
 
-            #{ $self }__image {
-                height: 130px;
-            }
-
             &#{ $self }--featured {
                 display: flex;
-                gap: 3.375rem;
+                gap: $p-gutter--large;
+
+                #{ $self }__title {
+                    @include style-heading-2;
+                }
 
                 #{ $self }__content {
+                    flex: 0 1 50%;
                     width: 50%;
                 }
 
                 #{ $self }__excerpt {
-                    color: $c-grey;
                     line-height: 2;
                 }
 
                 #{ $self }__image {
-                    height: 340px;
+                    aspect-ratio: 5 / 4;
+                    flex: 0 1 50%;
                     margin: 0;
                     width: 50%;
-                }
-
-                #{ $self }__title {
-                    font-size: 2rem;
                 }
             }
         }

--- a/hugo/layouts/blog/list.html
+++ b/hugo/layouts/blog/list.html
@@ -16,9 +16,9 @@
                         {{ range $index, $teaser := .Pages }}
                             <li class="list__item">
                                 {{- if eq $index 0 -}}
-                                        {{- partial "teaser--blog.html" (dict "modifier" "featured" "context" . "path" .File.Dir)  -}}
+                                    {{- partial "teaser--blog.html" (dict "modifier" "featured" "context" . "path" .File.Dir) -}}
                                 {{- else -}}
-                                        {{- partial "teaser--blog.html" . -}}
+                                    {{- partial "teaser--blog.html" . -}}
                                 {{- end -}}
                             </li>
                         {{ end }}
@@ -27,9 +27,7 @@
             </div>
 
             <footer class="section__footer">
-                <div class="section__content">
-                    {{- partial "paging/pages.html" . -}}
-                </div>
+                <div class="section__content">{{- partial "paging/pages.html" . -}}</div>
             </footer>
         {{ end }}
     </section>

--- a/hugo/layouts/partials/teaser--blog.html
+++ b/hugo/layouts/partials/teaser--blog.html
@@ -6,7 +6,7 @@
     {{- $context = .context -}}
     {{- $modifier = .modifier -}}
     {{- $path = .path -}}
-{{- else -}} 
+{{- else -}}
     {{- $context = . -}}
     {{- $path = .File.Dir -}}
 {{- end -}}
@@ -21,20 +21,27 @@
     <div class="teaser__content">
         <div class="teaser__heading">
             <h2 class="teaser__title">{{ $context.Title }}</h2>
+        </div>
+
+        <div class="teaser__meta">
+            <p class="teaser__date">
+                {{ $context.Date.Format ($context.Param "time_format") }}
+            </p>
+
             {{ if $context.Params.tags }}
                 {{ $tags := where $context.Site.Params.tags "name" "in"  $context.Params.tags }}
                 {{- partial "tags.html" (dict "listClass" "teaser__tags" "tags" $tags) -}}
             {{ end }}
         </div>
-        <p class="teaser__meta">{{ $context.Date.Format ($context.Param "time_format") }}</p>
-        <p class="teaser__excerpt">{{ $context.Summary | truncate 200 }}</p>
+
+        <p class="teaser__excerpt">{{ $context.Summary | truncate 220 }}</p>
+
         <div class="link teaser__readmore">
             <span class="link__text">{{ T "ui_read_more" }}</span>
         </div>
-    
+
         <a class="teaser__link" aria-label="{{ T "ui_read_more" }} - {{ $context.LinkTitle }}" href="{{ $context.RelPermalink }}">
             <span>{{ T "ui_read_more" }}</span>
         </a>
     </div>
-
 </article>


### PR DESCRIPTION
- Moved date above tags
- Made summary text slightly larger so the '...' doesn't fall on the next line
- Cleaned up the list.html
- Cleaned up teaser.scss
- Blog teaser css adjustments - featured images grows with the content hight - remove spacing on the sides - correct font colors

For https://linear.app/usmedia/issue/CUE-325