### PR TITLE
Hugo: fix html validation errors for itemprop

### DIFF
--- a/hugo/layouts/_default/baseof.html
+++ b/hugo/layouts/_default/baseof.html
@@ -1,19 +1,24 @@
 <!doctype html>
 <html lang="{{ .Site.Language.Lang }}" dir="{{ .Site.Language.LanguageDirection }}" class="no-js">
     <head>{{ partial "site/head.html" . }}</head>
-    <body{{ with .Params.body_class }} class="{{ . }}"{{ end }}>
+    <body{{ with .Params.body_class }} class="{{ . }}"{{ end }} itemscope itemtype="https://schema.org/WebPage">
+        {{ partial "schema/webpage.html" . }}
+        
         <a id="skip-nav" class="skip-link" href="#site-main" target="_self">{{ T "ui_skip_nav" }}</a>
         <div class="site">
             <header id="site-header" class="site__header">
                 {{ partialCached "site/header.html" . (.Params.header_type | default "") }}
             </header>
-            <main id="site-main" class="site__content">
+
+            <main id="site-main" class="site__content" itemprop="mainContentOfPage">
                 {{ block "main" . }}{{ end }}
             </main>
+
             <footer id="site-footer" class="site__footer">
                 {{ partialCached "site/footer.html" . }}
             </footer>
         </div>
+
         {{ partial "notification-bar.html" . }}
         {{ partialCached "site/drawer-mobile.html" . }}
         {{ partial "site/scripts.html" . }}

--- a/hugo/layouts/_default/single.html
+++ b/hugo/layouts/_default/single.html
@@ -1,7 +1,9 @@
 {{ define "main" }}
     {{ partial "paging/back-button.html" . }}
 
-    <article class="article">
+    <article class="article" itemscope itemtype="https://schema.org/Article">
+        {{ partial "schema/article.html" . }}
+
         <div class="article__container">
             {{- partial "article--header" (dict "showTitle" true "context" .) -}}
 

--- a/hugo/layouts/blog/single.html
+++ b/hugo/layouts/blog/single.html
@@ -1,7 +1,9 @@
 {{ define "main" }}
     {{ partial "paging/back-button.html" . }}
 
-    <article class="article article--blog">
+    <article class="article article--blog" itemscope itemtype="https://schema.org/BlogPosting">
+        {{ partial "schema/article.html" . }}
+
         <div class="article__container">
             {{- partial "article--header" (dict "showTitle" true "context" .) -}}
 

--- a/hugo/layouts/docs/single.html
+++ b/hugo/layouts/docs/single.html
@@ -4,7 +4,9 @@
         <div class="docs__main">
             {{ partial "paging/breadcrumb.html" . }}
 
-            <article class="article article--docs">
+            <article class="article article--docs" itemscope itemtype="https://schema.org/TechArticle">
+                {{ partial "schema/article.html" . }}
+
                 <div class="article__container">
                     {{ partial "article--header" (dict "showTitle" false "context" .) }}
 

--- a/hugo/layouts/partials/schema/article.html
+++ b/hugo/layouts/partials/schema/article.html
@@ -1,0 +1,2 @@
+<meta itemprop="articleBody" content="{{ .Content }}">
+<meta itemprop="wordCount" content="{{ .WordCount }}">

--- a/hugo/layouts/partials/schema/webpage.html
+++ b/hugo/layouts/partials/schema/webpage.html
@@ -1,0 +1,37 @@
+<meta itemprop="name" content="{{ .Title }}">
+<meta itemprop="description" content="{{ with .Description }}{{ . }}{{ else }}{{if .IsPage}}{{ .Summary }}{{ else }}{{ with .Site.Params.description }}{{ . }}{{ end }}{{ end }}{{ end }}">
+
+{{- if .IsPage -}}
+    {{- $iso8601 := "2006-01-02T15:04:05-07:00" -}}
+    {{ with .PublishDate }}
+        <meta itemprop="datePublished" {{ .Format $iso8601 | printf "content=%q" | safeHTMLAttr }} />
+    {{ end}}
+
+    {{ with .Lastmod }}
+        <meta itemprop="dateModified" {{ .Format $iso8601 | printf "content=%q" | safeHTMLAttr }} >
+    {{ end}}
+
+    {{- with $.Params.images -}}
+        {{- range first 6 . -}}
+            <meta itemprop="image" content="{{ . | absURL }}">
+        {{ end -}}
+    {{- else -}}
+        {{- $images := $.Resources.ByType "image" -}}
+        {{- $featured := $images.GetMatch "*feature*" -}}
+
+        {{- if not $featured }}
+            {{ $featured = $images.GetMatch "{*cover*,*thumbnail*}" }}
+        {{ end -}}
+
+        {{- with $featured -}}
+            <meta itemprop="image" content="{{ $featured.Permalink }}">
+        {{- else -}}
+            {{- with $.Site.Params.images -}}
+                <meta itemprop="image" content="{{ index . 0 | absURL }}"/>
+            {{ end -}}
+        {{- end -}}
+    {{- end -}}
+
+    <!-- Output all taxonomies as schema.org keywords -->
+    <meta itemprop="keywords" content="{{ if .IsPage}}{{ range $index, $tag := .Params.tags }}{{ $tag }},{{ end }}{{ else }}{{ range $plural, $terms := .Site.Taxonomies }}{{ range $term, $val := $terms }}{{ printf "%s," $term }}{{ end }}{{ end }}{{ end }}" />
+{{- end -}}

--- a/hugo/layouts/partials/share.html
+++ b/hugo/layouts/partials/share.html
@@ -8,7 +8,7 @@
         <li class="share__item" data-copy>
             <button class="share__copy" data-copy-button data-copy-type="url" data-copy-value="{{ .Permalink }}">
                 {{ partial "icon.html" (dict "icon" "link" "class" "share__icon") }}
-                <p><span class="share__link-text">{{ T "share_copy_link" }}</span></p>
+                <span class="share__link-text">{{ T "share_copy_link" }}</span>
                 <span class="share__copy-message is-hidden" data-copy-message aria-hidden="true">
                     {{ T "copy_message" }}
                 </span>

--- a/hugo/layouts/partials/site/head.html
+++ b/hugo/layouts/partials/site/head.html
@@ -16,7 +16,6 @@
 {{ partialCached "site/favicons.html" . }}
 <title>{{ if .IsHome }}{{ .Site.Title }}{{ else }}{{ with .Title }}{{ . }} | {{ end }}{{ .Site.Title }}{{ end }}</title>
 {{- template "_internal/opengraph.html" . -}}
-{{- template "_internal/schema.html" . -}}
 {{- template "_internal/twitter_cards.html" . -}}
 {{ if eq (getenv "HUGO_ENV") "production" }}
     {{ template "_internal/google_analytics_async.html" . }}


### PR DESCRIPTION
- Copied hugo internal schema so it can be adjusted to our needs
- Moved schema into base so the itemprops have a (correct) parent
- Added initial setup article schema

To test:
- Enter url into https://validator.w3.org/
- Enter url into https://validator.schema.org/ You should not encounter any errors or warnings about itemprops or related schema issues in the w3 validator.
You should not encounter any errors or warnings in the schema.org validator

For https://linear.app/usmedia/issue/CUE-315