### PR TITLE
Hugo: re-align sidenote with headings

### DIFF
--- a/content/examples/shortcodes/sidenote/en.md
+++ b/content/examples/shortcodes/sidenote/en.md
@@ -3,9 +3,10 @@ title: Sidenote
 weight: 30
 ---
 
-{{< sidenote text="Only in CUE v04.3" >}}
 
 This is a shortcode that can be used to create a sidenote (ie. a 'pill' on the side of the content).
+
+{{< sidenote text="Only in CUE v04.3" >}}
 
 This way content-writers can mark headers with an additional note.
 

--- a/hugo/assets/scss/components/sidenote.scss
+++ b/hugo/assets/scss/components/sidenote.scss
@@ -25,7 +25,11 @@
     width: fit-content;
 
     h1 + & {
-        margin-top: -0.5em;
+        margin-top: -1.75rem;
+    }
+
+    h2 + & {
+        margin-top: -0.5rem;
     }
 
     @include screen($screen-simple) {
@@ -35,15 +39,18 @@
         max-width: 250px;
 
         h1 + & {
-            margin-top: calc((var(--sidenote-height) + 1rem) * -1);
+            margin-top: calc((var(--sidenote-height) + 2.5rem) * -1);
         }
 
         h2 + & {
-            margin-top: calc((var(--sidenote-height) + 0.7rem) * -1);
+            margin-top: calc((var(--sidenote-height) + 1rem) * -1);
         }
 
         h3 + &,
-        h4 + &,
+        h4 + & {
+            margin-top: calc((var(--sidenote-height) + 0.375rem) * -1);
+        }
+
         h5 + &,
         h6 + & {
             margin-top: calc((var(--sidenote-height) + 0.25rem) * -1);

--- a/hugo/content/en/examples/shortcodes/sidenote/index.md
+++ b/hugo/content/en/examples/shortcodes/sidenote/index.md
@@ -3,9 +3,10 @@ title: Sidenote
 weight: 30
 ---
 
-{{< sidenote text="Only in CUE v04.3" >}}
 
 This is a shortcode that can be used to create a sidenote (ie. a 'pill' on the side of the content).
+
+{{< sidenote text="Only in CUE v04.3" >}}
 
 This way content-writers can mark headers with an additional note.
 


### PR DESCRIPTION
- Finetune the margins so the sidenote is aligning with the headings again
- Move example sidenote so it doesn't look like it should align with the article title

For https://linear.app/usmedia/issue/CUE-326