### PR TITLE
Hugo: Add optionality to search for authors

### DIFF
--- a/hugo/algolia-settings.js
+++ b/hugo/algolia-settings.js
@@ -20,8 +20,8 @@ const index = client.initIndex(indexName);
 
 index.setSettings({
     queryLanguages: ['en'],
-    searchableAttributes: ['title', 'content', 'summary', 'tags', 'contentType'],
-    attributesForFaceting: ['tags', 'contentType'],
+    searchableAttributes: ['title', 'content', 'summary', 'tags', 'contentType', 'authors'],
+    attributesForFaceting: ['tags', 'contentType', 'authors'],
     distinct: true,
     attributeForDistinct: 'link',
     highlightPreTag: '<strong>',

--- a/hugo/assets/ts/helpers/search.ts
+++ b/hugo/assets/ts/helpers/search.ts
@@ -10,6 +10,8 @@ import { cleanObject } from './cleaner';
 
 export const getFacetForInputName = (inputName: SearchInputFacetName): SearchFacet => {
     switch (inputName) {
+        case SearchInputFacetName.AUTHOR:
+            return SearchFacet.AUTHORS;
         case SearchInputFacetName.CONTENT_TYPE:
             return SearchFacet.CONTENT_TYPE;
         case SearchInputFacetName.TAG:
@@ -21,6 +23,8 @@ export const getFacetForInputName = (inputName: SearchInputFacetName): SearchFac
 
 export const getInputNameForFacet = (facet: SearchFacet): SearchInputFacetName => {
     switch (facet) {
+        case SearchFacet.AUTHORS:
+            return SearchInputFacetName.AUTHOR;
         case SearchFacet.CONTENT_TYPE:
             return SearchInputFacetName.CONTENT_TYPE;
         case SearchFacet.TAGS:
@@ -34,6 +38,7 @@ export const mapToAlgoliaFilters = (tagsByFacet: SearchFacets, operator: FilterO
     return Object.keys(tagsByFacet)
         .map((facet) => {
             const facetOperator = {
+                [SearchInputFacetName.AUTHOR]: ' OR ',
                 [SearchInputFacetName.CONTENT_TYPE]: ' OR ',
                 [SearchInputFacetName.TAG]: ' AND ',
             }[facet] ?? ' AND ';
@@ -62,12 +67,14 @@ export const parseQuery = (query: string): ParsedQuery => {
     let cleanQuery = query;
 
     const facets: SearchFacets = {
+        [SearchFacet.AUTHORS]: [],
         [SearchFacet.TAGS]: [],
         [SearchFacet.CONTENT_TYPE]: [],
     };
 
     for (const facetInput of FACET_INPUTS) {
         const facet = getFacetForInputName(facetInput);
+
         if (!facet) {
             continue;
         }
@@ -75,6 +82,7 @@ export const parseQuery = (query: string): ParsedQuery => {
         const regExp = new RegExp(`${ facetInput }:([^"]\\S+)`, 'g');
         const regExpWithQuotes = new RegExp(`${ facetInput }:"([^"]+)"|(\\+)`, 'g');
         const matches = [ ...query.matchAll(regExp), ...query.matchAll(regExpWithQuotes) ];
+
         for (const match of matches) {
             if (match) {
                 if (match[1] && match[1] !== '') {

--- a/hugo/assets/ts/interfaces/search.ts
+++ b/hugo/assets/ts/interfaces/search.ts
@@ -8,6 +8,7 @@ export interface SearchItem {
     breadcrumb: string[];
     contentType: string;
     tags: string | string[];
+    authors: string | string[];
 }
 
 export interface FilterItem {
@@ -21,16 +22,19 @@ export enum FilterOperator {
 }
 
 export enum SearchInputFacetName {
+    AUTHOR = 'author',
     CONTENT_TYPE = 'contentType',
     TAG = 'tag',
 }
 
 export const FACET_INPUTS = [
+    SearchInputFacetName.AUTHOR,
     SearchInputFacetName.CONTENT_TYPE,
     SearchInputFacetName.TAG,
 ];
 
 export enum SearchFacet {
+    AUTHORS = 'authors',
     CONTENT_TYPE = 'contentType',
     TAGS = 'tags',
 }

--- a/hugo/assets/ts/widgets/search-autocomplete.ts
+++ b/hugo/assets/ts/widgets/search-autocomplete.ts
@@ -169,7 +169,8 @@ export class SearchAutocomplete extends BaseWidget {
                             return html`
                                 <a class="searchbar__item" href="${ item.link }">
                                     <div class="searchbar__item-content">
-                                        ${ ((item.breadcrumb as SearchItem['breadcrumb']) && (item.breadcrumb as SearchItem['breadcrumb']).length >= 0) ? html`
+                                        ${ ((item.breadcrumb as SearchItem['breadcrumb']) &&
+                                        (item.breadcrumb as SearchItem['breadcrumb']).length >= 0) ? html`
                                             <div class="searchbar__breadcrumb">
                                                 ${ (item.breadcrumb as SearchItem['breadcrumb']).map((breadcrumb: string) => html`
                                                     <span>${ breadcrumb }</span>

--- a/hugo/assets/ts/widgets/search-filter.ts
+++ b/hugo/assets/ts/widgets/search-filter.ts
@@ -128,13 +128,13 @@ export class SearchFilter extends BaseWidget {
         const query = searchParams.get('q');
 
         this.parsedQuery = parseQuery(query);
+
         if (!query) {
             this.selectedItems = [];
         } else {
             this.selectedItems = this.parsedQuery.facets[this.filterName] ?? [];
         }
     }
-
 }
 
 if (document.readyState !== 'loading') {

--- a/hugo/layouts/_default/list.algolia.json
+++ b/hugo/layouts/_default/list.algolia.json
@@ -32,6 +32,7 @@
     {{- $tags := cond (isset $page.Params "tags") ($page.Params.tags) "" -}}
     {{- $contentType := $page.FirstSection.Title -}}
     {{- $breadcrumb := slice -}}
+    {{- $authors := cond (isset $page.Params "authors") ($page.Params.authors) "" -}}
 
     {{/* If section is docs we derive the content type from the first level of nesting within docs*/}}
     {{- if and (eq $page.Section "docs") (ne $page $page.FirstSection) -}}
@@ -73,7 +74,8 @@
         "content": {{ $content  | jsonify}},
         "breadcrumb": {{ $breadcrumb | jsonify }},
         "contentType": {{ $contentType | jsonify }},
-        "tags": {{ $tags | jsonify }}
+        "tags": {{ $tags | jsonify }},
+        "authors": {{ $authors | jsonify }}
     }
 
     {{- if gt $page.PlainWords (add $cutoff $skipWords) -}},


### PR DESCRIPTION
- Add authors to algolia search results
- Add author search optionality to ts
- Extend algolia settings > 'searchableAttributes' and 'attributesForFaceting' with authors

For testing:
1. set up a testing index in Algolia > follow walkthrough in hugo > readme
2. change the environments to your test index in the search-results.ts
3. run the project and eg go to /blog/example/ and click on an author
> search all content by this author

-> you are redirected to the search results page with the author query, and will see all the pages by this author.
For example: /search/?q=author:pauljolly

For https://linear.app/usmedia/issue/CUE-266