### PR TITLE
Hugo: change html element for drawer menu

### DIFF
--- a/hugo/layouts/partials/site/drawer-mobile.html
+++ b/hugo/layouts/partials/site/drawer-mobile.html
@@ -1,5 +1,6 @@
 {{ $baseUrl := urls.Parse $.Site.Params.Baseurl }}
-<section id="mobile-menu" class="drawer drawer--mobile" data-drawer="menu">
+
+<div id="mobile-menu" class="drawer drawer--mobile" data-drawer="menu">
     <div class="drawer__backdrop" data-drawer-close="menu"></div>
     <div class="drawer__container" tabindex="0">
         <div class="drawer__header">
@@ -73,4 +74,4 @@
             </nav>
         </div>
     </div>
-</section>
+</div>


### PR DESCRIPTION
- Change section to div since section needs a header

To test:
Copy the source or url and paste in https://validator.w3.org/, you should not see the "section doesn't have a heading" error

For https://linear.app/usmedia/issue/CUE-317