### PR TITLE
playground: Examples

### DIFF
--- a/playground/package-lock.json
+++ b/playground/package-lock.json
@@ -9,12 +9,15 @@
       "version": "0.1.0",
       "dependencies": {
         "@monaco-editor/react": "4.5.1",
+        "fuse.js": "6.6.2",
+        "lodash.clonedeep": "4.5.0",
         "lodash.debounce": "4.0.8",
         "react": "18.2.0",
         "react-dom": "18.2.0",
         "react-scripts": "5.0.1"
       },
       "devDependencies": {
+        "@types/lodash.clonedeep": "4.5.7",
         "@types/lodash.debounce": "4.0.7",
         "@types/react": "18.0.28",
         "@types/react-dom": "18.0.10",
@@ -3216,6 +3219,15 @@
       "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.195.tgz",
       "integrity": "sha512-Hwx9EUgdwf2GLarOjQp5ZH8ZmblzcbTBC2wtQWNKARBSxM9ezRIAUpeDTgoQRAFB0+8CNWXVA9+MaSOzOF3nPg==",
       "dev": true
+    },
+    "node_modules/@types/lodash.clonedeep": {
+      "version": "4.5.7",
+      "resolved": "https://registry.npmjs.org/@types/lodash.clonedeep/-/lodash.clonedeep-4.5.7.tgz",
+      "integrity": "sha512-ccNqkPptFIXrpVqUECi60/DFxjNKsfoQxSQsgcBJCX/fuX1wgyQieojkcWH/KpE3xzLoWN/2k+ZeGqIN3paSvw==",
+      "dev": true,
+      "dependencies": {
+        "@types/lodash": "*"
+      }
     },
     "node_modules/@types/lodash.debounce": {
       "version": "4.0.7",
@@ -7296,6 +7308,14 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/fuse.js": {
+      "version": "6.6.2",
+      "resolved": "https://registry.npmjs.org/fuse.js/-/fuse.js-6.6.2.tgz",
+      "integrity": "sha512-cJaJkxCCxC8qIIcPBF9yGxY0W/tVZS3uEISDxhYIdtk8OL93pe+6Zj7LjCqVV4dzbqcriOZ+kQ/NE4RXZHsIGA==",
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/gensync": {
       "version": "1.0.0-beta.2",
       "license": "MIT",
@@ -9490,6 +9510,11 @@
     "node_modules/lodash": {
       "version": "4.17.21",
       "license": "MIT"
+    },
+    "node_modules/lodash.clonedeep": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz",
+      "integrity": "sha512-H5ZhCF25riFd9uB5UCkVKo61m3S/xZk1x4wA6yp/L3RFP6Z/eHH1ymQcGLo7J3GMPfm0V/7m1tryHuGVxpqEBQ=="
     },
     "node_modules/lodash.debounce": {
       "version": "4.0.8",
@@ -16323,6 +16348,15 @@
       "integrity": "sha512-Hwx9EUgdwf2GLarOjQp5ZH8ZmblzcbTBC2wtQWNKARBSxM9ezRIAUpeDTgoQRAFB0+8CNWXVA9+MaSOzOF3nPg==",
       "dev": true
     },
+    "@types/lodash.clonedeep": {
+      "version": "4.5.7",
+      "resolved": "https://registry.npmjs.org/@types/lodash.clonedeep/-/lodash.clonedeep-4.5.7.tgz",
+      "integrity": "sha512-ccNqkPptFIXrpVqUECi60/DFxjNKsfoQxSQsgcBJCX/fuX1wgyQieojkcWH/KpE3xzLoWN/2k+ZeGqIN3paSvw==",
+      "dev": true,
+      "requires": {
+        "@types/lodash": "*"
+      }
+    },
     "@types/lodash.debounce": {
       "version": "4.0.7",
       "resolved": "https://registry.npmjs.org/@types/lodash.debounce/-/lodash.debounce-4.0.7.tgz",
@@ -18809,6 +18843,11 @@
     "functions-have-names": {
       "version": "1.2.3"
     },
+    "fuse.js": {
+      "version": "6.6.2",
+      "resolved": "https://registry.npmjs.org/fuse.js/-/fuse.js-6.6.2.tgz",
+      "integrity": "sha512-cJaJkxCCxC8qIIcPBF9yGxY0W/tVZS3uEISDxhYIdtk8OL93pe+6Zj7LjCqVV4dzbqcriOZ+kQ/NE4RXZHsIGA=="
+    },
     "gensync": {
       "version": "1.0.0-beta.2"
     },
@@ -20142,6 +20181,11 @@
     },
     "lodash": {
       "version": "4.17.21"
+    },
+    "lodash.clonedeep": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz",
+      "integrity": "sha512-H5ZhCF25riFd9uB5UCkVKo61m3S/xZk1x4wA6yp/L3RFP6Z/eHH1ymQcGLo7J3GMPfm0V/7m1tryHuGVxpqEBQ=="
     },
     "lodash.debounce": {
       "version": "4.0.8"

--- a/playground/package.json
+++ b/playground/package.json
@@ -5,6 +5,8 @@
   "author": "",
   "main": "index.js",
   "dependencies": {
+    "fuse.js": "6.6.2",
+    "lodash.clonedeep": "4.5.0",
     "lodash.debounce": "4.0.8",
     "@monaco-editor/react": "4.5.1",
     "react": "18.2.0",
@@ -12,6 +14,7 @@
     "react-scripts": "5.0.1"
   },
   "devDependencies": {
+    "@types/lodash.clonedeep": "4.5.7",
     "@types/lodash.debounce": "4.0.7",
     "@types/react": "18.0.28",
     "@types/react-dom": "18.0.10",

--- a/playground/src/components/examples-menu.tsx
+++ b/playground/src/components/examples-menu.tsx
@@ -1,0 +1,136 @@
+import * as React from 'react';
+import { MutableRefObject } from 'react';
+import Fuse from 'fuse.js';
+import { Example, ExamplesByCategory } from '@models/example';
+import { examples } from '@config/examples';
+import { categoryWeight } from '@config/examples/categories';
+import { getSearchParamsFromUrl, updateSearchParams } from '@helpers/url-params';
+import cx from 'classnames';
+
+interface ExampleMenuProps {
+    activeExample?: Example;
+    onClose?: () => void;
+}
+
+interface ExampleMenuState {
+    filteredExamples: ExamplesByCategory[];
+}
+
+export class ExamplesMenu extends React.Component<ExampleMenuProps, ExampleMenuState> {
+    private fuse: Fuse<Example>;
+
+    public inputRef: MutableRefObject<HTMLInputElement>;
+
+    constructor(props: ExampleMenuProps) {
+        super(props);
+
+        this.inputRef = React.createRef();
+        this.state = {
+            filteredExamples: this.examplesByCategory(examples),
+        };
+
+        const options = {
+            keys: ['title'],
+            threshold: 0.4,
+        };
+        this.fuse = new Fuse(examples, options);
+    }
+
+    public search() {
+        const value = this.inputRef.current.value;
+        let result: Example[];
+        if (value && value !== '') {
+            result = this.fuse.search(value).map(result => result.item);
+        } else {
+            result = examples;
+        }
+
+        this.setState( {
+            filteredExamples: this.examplesByCategory(result),
+        });
+    }
+
+    public examplesByCategory(exampleItems: Example[]): ExamplesByCategory[] {
+        const categories: {[key: string]: Example[] } = {};
+        // First put examples in the right categories
+        for (const example of exampleItems) {
+            if (!categories[example.category]) {
+                categories[example.category] = [];
+            }
+
+            categories[example.category].push(example);
+        }
+
+        const sortedCategories: ExamplesByCategory[] = [];
+
+        // Sort the result
+        Object.keys(categories)
+            .sort((a, b) => {
+                const weightA = categoryWeight[a] ?? 1;
+                const weightB = categoryWeight[b] ?? 1;
+                return weightA - weightB;
+            })
+            .forEach((key) => {
+                sortedCategories.push({
+                    category: key,
+                    examples: categories[key],
+                })
+            });
+
+        return sortedCategories;
+    }
+
+    public updateUrl(example: Example) {
+        const params = getSearchParamsFromUrl();
+        params.set('example', example.slug);
+        updateSearchParams(params);
+        this.props.onClose();
+    }
+
+    public render() {
+        const items = [];
+        for (const item of this.state.filteredExamples) {
+            items.push(<li className="cue-example-menu__item cue-example-menu__item--category" key={ item.category }>
+                <p className="cue-example-menu__category">{ item.category }</p>
+                <ul className="cue-example-menu__items cue-example-menu__items--children">
+                    { item.examples.map(example => {
+                        const isActive = example.slug === this.props.activeExample?.slug;
+                        const linkClassnames = cx({
+                            'is-active': isActive,
+                        }, 'cue-example-menu__link');
+
+                        return (
+                            <li className="cue-example-menu__item" key={ example.slug }>
+                                <button className={ linkClassnames }
+                                        onClick={ () =>{ this.updateUrl(example) } }>
+                                    <span className="cue-example-menu__text">{ example.title }</span>
+                                </button>
+                            </li>
+                        );
+                    })}
+                </ul>
+            </li>);
+        }
+
+        return (
+            <div className="cue-example-menu">
+                <div className="cue-example-menu__header">
+                    <div className="cue-example-menu__search">
+                        <label className="cue-example-menu__label" htmlFor="example-search">Search</label>
+                        <input type="text" className="cue-example-menu__input"
+                               name="example-search" id="example-search" placeholder="Search"
+                               ref={ this.inputRef } onChange={ this.search.bind(this) }
+                        />
+                    </div>
+                </div>
+                <div className="cue-example-menu__content">
+                    { this.state.filteredExamples.length ?
+                        (<ul className="cue-example-menu__items">
+                            { items }
+                        </ul>)
+                    : ( <p className="cue-example-menu__empty">No results found for search term</p>)}
+                </div>
+            </div>
+        );
+    }
+}

--- a/playground/src/components/header.tsx
+++ b/playground/src/components/header.tsx
@@ -6,8 +6,11 @@ import { DropdownChange } from '@models/dropdown';
 import { Menu } from '@components/menu';
 import { Share } from '@components/share';
 import { WorkspaceMenu } from '@components/workspace-menu';
+import { ExamplesMenu } from '@components/examples-menu';
+import { Example } from '@models/example';
 
 interface HeaderProps {
+    activeExample?: Example;
     activeWorkspaceName: WORKSPACE;
     workspaces: Workspaces;
     saved: boolean;
@@ -19,6 +22,7 @@ interface HeaderProps {
 }
 
 interface HeaderState {
+    examplesMenuOpen: boolean;
     workspaceMenuOpen: boolean;
 }
 
@@ -28,6 +32,7 @@ export class Header extends React.Component<HeaderProps, HeaderState>
     constructor(props: HeaderProps) {
         super(props);
         this.state = {
+            examplesMenuOpen: false,
             workspaceMenuOpen: false,
         }
     }
@@ -67,10 +72,20 @@ export class Header extends React.Component<HeaderProps, HeaderState>
                             onClose={ () => { this.setState({ workspaceMenuOpen: false })} }
                         ></WorkspaceMenu>
                     </Menu>
-                    <Menu id="examples" title="Examples">
-                        <div className="cue-menu__content">
-                            <span>Coming soon!</span>
-                        </div>
+                    <Menu id="examples"
+                          title="Examples"
+                          cssClass="cue-menu--wide"
+                          onOpen={ () => {
+                              this.setState({ examplesMenuOpen: true })
+                          } }
+                          onClose={ () => {
+                              this.setState({ examplesMenuOpen: false })
+                          } }
+                    >
+                        <ExamplesMenu
+                            activeExample={ this.props.activeExample }
+                            onClose={ () => { this.setState({ examplesMenuOpen: false })} }
+                        ></ExamplesMenu>
                     </Menu>
                 </div>
 

--- a/playground/src/components/spinner.tsx
+++ b/playground/src/components/spinner.tsx
@@ -1,0 +1,22 @@
+import * as React from 'react';
+
+interface SpinnerProps {
+    className?: string;
+}
+
+export class Spinner extends React.Component<SpinnerProps> {
+    constructor(props: SpinnerProps) {
+        super(props);
+    }
+
+    public render() {
+        return (
+            <div className=" cue-spinner">
+                <div className="cue-spinner__item"></div>
+                <div className="cue-spinner__item"></div>
+                <div className="cue-spinner__item"></div>
+                <p className="cue-spinner__text">loading</p>
+            </div>
+        );
+    }
+}

--- a/playground/src/components/workspace-menu.tsx
+++ b/playground/src/components/workspace-menu.tsx
@@ -6,7 +6,7 @@ import { availableWorkspaces } from '@config/workspaces';
 import { DropdownChange } from '@models/dropdown';
 import { OPTION_TYPE } from '@models/options';
 import { Workspace, Workspaces } from '@models/workspace';
-import { workspaceToHashParams } from '@helpers/hash-params';
+import { workspaceToHashParams } from '@helpers/url-params';
 
 interface WorkspaceMenuProps {
     activeWorkspace: Workspace;

--- a/playground/src/config/examples/categories.ts
+++ b/playground/src/config/examples/categories.ts
@@ -1,0 +1,4 @@
+export const categoryWeight: {[key: string]: number } = {
+    'Category 1': 10,
+    'Category 2': 20,
+}

--- a/playground/src/config/examples/example.ts
+++ b/playground/src/config/examples/example.ts
@@ -1,0 +1,29 @@
+import { cloneDeep } from 'lodash';
+import { Example } from '@models/example';
+import { WORKSPACE, WorkspaceConfig } from '@models/workspace';
+import { functionWorkspace } from '@config/workspaces';
+import { OPTION_TYPE } from '@models/options';
+
+/*  In the future we can also let the pre-processor create examples based on one of the workspace config's
+    instead of doing it with typescript. Make sure the example follows the Example model and the config
+    is correct for the chosen workspace. */
+
+// Clone config because we don't want to change the original workspace config
+const config = cloneDeep<WorkspaceConfig>(functionWorkspace.config);
+
+export const testExample: Example = {
+    slug: 'test-example',
+    title: 'Test example',
+    category: 'Category 1',
+    workspace: WORKSPACE.FUNC,
+    workspaceConfig: {
+        ...config,
+        inputTabs: config.inputTabs.map((tab) => {
+            if (tab.type === OPTION_TYPE.INPUT) {
+                tab.code = 'Examples are coming soon!';
+            }
+            return tab;
+        }),
+    },
+}
+

--- a/playground/src/config/examples/example2.ts
+++ b/playground/src/config/examples/example2.ts
@@ -1,0 +1,29 @@
+import { cloneDeep } from 'lodash';
+import { Example } from '@models/example';
+import { WORKSPACE, WorkspaceConfig } from '@models/workspace';
+import { functionWorkspace } from '@config/workspaces';
+import { OPTION_TYPE } from '@models/options';
+
+/*  In the future we can also let the pre-processor create examples based on one of the workspace config's
+    instead of doing it with typescript. Make sure the example follows the Example model and the config
+    is correct for the chosen workspace. */
+
+// Clone config because we don't want to change the original workspace config
+const config = cloneDeep<WorkspaceConfig>(functionWorkspace.config);
+
+export const testExample2: Example = {
+    slug: 'test-example-2',
+    title: 'Another example',
+    category: 'Category 2',
+    workspace: WORKSPACE.FUNC,
+    workspaceConfig: {
+        ...config,
+        inputTabs: config.inputTabs.map((tab) => {
+            if (tab.type === OPTION_TYPE.INPUT) {
+                tab.code = 'Examples are coming soon!';
+            }
+            return tab;
+        }),
+    },
+}
+

--- a/playground/src/config/examples/example3.ts
+++ b/playground/src/config/examples/example3.ts
@@ -1,0 +1,32 @@
+import { cloneDeep } from 'lodash';
+import { Example } from '@models/example';
+import { WORKSPACE, WorkspaceConfig } from '@models/workspace';
+import { policyWorkspace } from '@config/workspaces';
+import { OPTION_TYPE } from '@models/options';
+
+/*  In the future we can also let the pre-processor create examples based on one of the workspace config's
+    instead of doing it with typescript. Make sure the example follows the Example model and the config
+    is correct for the chosen workspace. */
+
+// Clone config because we don't want to change the original workspace config
+const config = cloneDeep<WorkspaceConfig>(policyWorkspace.config);
+
+export const testExample3: Example = {
+    slug: 'test-example-3',
+    title: 'Some other example',
+    category: 'Category 2',
+    workspace: WORKSPACE.POLICY,
+    workspaceConfig: {
+        ...config,
+        inputTabs: config.inputTabs.map((tab) => {
+            if (tab.type === OPTION_TYPE.INPUT) {
+                tab.code = 'Examples for policy input are coming soon!';
+            }
+            if (tab.type === OPTION_TYPE.POLICY) {
+                tab.code = 'Examples for policy are coming soon!';
+            }
+            return tab;
+        }),
+    },
+}
+

--- a/playground/src/config/examples/index.ts
+++ b/playground/src/config/examples/index.ts
@@ -1,0 +1,11 @@
+import { Example } from '@models/example';
+import { testExample } from '@config/examples/example';
+import { cloneDeep } from 'lodash';
+import { testExample2 } from '@config/examples/example2';
+import { testExample3 } from '@config/examples/example3';
+
+export const examples: Example[] = [
+    cloneDeep(testExample),
+    cloneDeep(testExample2),
+    cloneDeep(testExample3),
+];

--- a/playground/src/config/workspaces/function.ts
+++ b/playground/src/config/workspaces/function.ts
@@ -1,7 +1,8 @@
 import { Workspace, WORKSPACE } from '@models/workspace';
 import { OPTION_TYPE, optionCUE, optionDef, optionExport, optionJSON, optionYAML } from '@models/options';
+import { deepFreeze } from '@helpers/deep-freeze';
 
-export const functionWorkspace: Workspace = {
+export const functionWorkspace: Workspace = deepFreeze<Workspace>({
     enabled: true,
     type: WORKSPACE.FUNC,
     title: 'Function',
@@ -27,4 +28,4 @@ export const functionWorkspace: Workspace = {
             selected: optionCUE,
         }
     }
-};
+});

--- a/playground/src/config/workspaces/index.ts
+++ b/playground/src/config/workspaces/index.ts
@@ -2,16 +2,17 @@ import { functionWorkspace } from '@config/workspaces/function';
 import { policyWorkspace } from '@config/workspaces/policy';
 import { jsonValidationWorkspace } from '@config/workspaces/jsonValidation';
 import { WORKSPACE, Workspaces } from '@models/workspace';
+import { cloneDeep } from 'lodash';
 
 export * from './function';
 export * from './jsonValidation';
 export * from './policy';
 
+// We need clone deep here because we don't want to reference the original config object
 export const availableWorkspaces: Workspaces = {
-    [WORKSPACE.FUNC]: functionWorkspace,
-    [WORKSPACE.POLICY]: policyWorkspace,
-    [WORKSPACE.JSON_VALIDATION]: jsonValidationWorkspace,
+    [WORKSPACE.FUNC]: cloneDeep(functionWorkspace),
+    [WORKSPACE.POLICY]: cloneDeep(policyWorkspace),
+    [WORKSPACE.JSON_VALIDATION]: cloneDeep(jsonValidationWorkspace),
 }
 
-export const defaultWorkspace = functionWorkspace;
-export const defaultWorkspaceName = WORKSPACE.FUNC;
+export const defaultWorkspace = cloneDeep(functionWorkspace);

--- a/playground/src/config/workspaces/jsonValidation.ts
+++ b/playground/src/config/workspaces/jsonValidation.ts
@@ -1,10 +1,11 @@
 import { WORKSPACE, Workspace } from '@models/workspace';
+import { deepFreeze } from '@helpers/deep-freeze';
 
-export const jsonValidationWorkspace: Workspace = {
+export const jsonValidationWorkspace: Workspace = deepFreeze<Workspace>({
     enabled: false,
     type: WORKSPACE.JSON_VALIDATION,
     title: 'JSON Validation',
     description: '',
     icon: 'workspace-json-validation',
     config: null,
-}
+});

--- a/playground/src/config/workspaces/policy.ts
+++ b/playground/src/config/workspaces/policy.ts
@@ -1,7 +1,8 @@
 import { WORKSPACE, Workspace } from '@models/workspace';
 import { OPTION_TYPE, optionCUE, optionJSON, optionTerminal, optionYAML } from '@models/options';
+import { deepFreeze } from '@helpers/deep-freeze';
 
-export const policyWorkspace: Workspace = {
+export const policyWorkspace: Workspace = deepFreeze<Workspace>({
     enabled: true,
     type: WORKSPACE.POLICY,
     title: 'Policy',
@@ -39,4 +40,4 @@ export const policyWorkspace: Workspace = {
             selected: optionCUE,
         }
     }
-};
+});

--- a/playground/src/helpers/deep-freeze.ts
+++ b/playground/src/helpers/deep-freeze.ts
@@ -1,0 +1,12 @@
+export const deepFreeze = <T extends { [key: string]: any }>(object: T): T => {
+    if (!object) {
+        return object;
+    }
+    Object.keys(object).forEach(prop => {
+        if (typeof object[prop] === 'object') {
+            deepFreeze(object[prop]);
+
+        }
+    });
+    return Object.freeze(object);
+};

--- a/playground/src/helpers/index.ts
+++ b/playground/src/helpers/index.ts
@@ -1,5 +1,5 @@
 export * from './cleaner';
-export * from './hash-params';
+export * from './url-params';
 export * from './share';
 export * from './wasm';
 export * from './workspace';

--- a/playground/src/helpers/url-params.ts
+++ b/playground/src/helpers/url-params.ts
@@ -3,7 +3,11 @@ import { OPTION_TYPE } from '@models/options';
 import { HASH_KEY, hashParams } from '@models/hashParams';
 import { cleanObject } from '@helpers/cleaner';
 
-export const getParamsFromUrl = (): hashParams => {
+export const getSearchParamsFromUrl = (): URLSearchParams => {
+    return new URLSearchParams(window.location.search);
+}
+
+export const getHashParamsFromUrl = (): hashParams => {
     let hash = window.location.hash.slice(1);
     const params: hashParams = {};
 
@@ -26,6 +30,29 @@ export const getParamsFromUrl = (): hashParams => {
     }
 
     return params;
+}
+
+export const updateHash = (newHash: string, replace = false): void => {
+    const currentHash = window.location.hash.slice(1);
+    if (currentHash !== newHash) {
+        if (replace) {
+            const newUrl = window.location;
+            newUrl.hash = newHash;
+            window.history.replaceState(null, '', newUrl.toString());
+        } else {
+            window.location.hash = newHash;
+        }
+    }
+}
+
+export const updateSearchParams = (searchParams: URLSearchParams, replace = false): void => {
+    if (replace) {
+        const newUrl = window.location;
+        newUrl.search = searchParams.toString();
+        window.history.pushState(null, '', newUrl.toString());
+    } else {
+        window.location.search = searchParams.toString();
+    }
 }
 
 export const workspaceToHashParams = (workspace: Workspace): string => {

--- a/playground/src/helpers/workspace.ts
+++ b/playground/src/helpers/workspace.ts
@@ -1,7 +1,7 @@
 import { Workspace } from '@models/workspace';
 import { HASH_KEY, hashParams } from '@models/hashParams';
 import { OPTION_TYPE } from '@models/options';
-import { optionToHashkey } from '@helpers/hash-params';
+import { optionToHashkey } from '@helpers/url-params';
 
 export const setupWorkspaceConfig = (workspace: Workspace, params: hashParams): Workspace => {
     // Loop through input tabs for workspace and set selected values to values from params

--- a/playground/src/models/example.ts
+++ b/playground/src/models/example.ts
@@ -1,0 +1,14 @@
+import { WORKSPACE, WorkspaceConfig } from '@models/workspace';
+
+export interface Example {
+    slug: string;
+    title: string;
+    category: string;
+    workspace: WORKSPACE,
+    workspaceConfig: WorkspaceConfig;
+}
+
+export interface ExamplesByCategory {
+    category: string;
+    examples: Example[];
+}

--- a/playground/src/models/index.ts
+++ b/playground/src/models/index.ts
@@ -1,4 +1,5 @@
 export * from './dropdown';
+export * from './example';
 export * from './hashParams';
 export * from './nav';
 export * from './options';

--- a/playground/src/scss/components/example-menu.scss
+++ b/playground/src/scss/components/example-menu.scss
@@ -1,0 +1,125 @@
+@import '../config/colors';
+@import '../config/prefix';
+@import '../config/sizes';
+@import '../config/typography';
+@import '../mixins/list-reset';
+@import '../mixins/svg';
+@import '../mixins/sr-only';
+
+.#{ $prefix }-example-menu {
+    $self: &;
+
+    &__header {
+        border-bottom: 1px solid $c-grey--light;
+        padding: 1rem;
+    }
+
+    &__label {
+        @include sr-only;
+    }
+
+    &__input {
+        &[type='text'] {
+            appearance: none;
+            background: transparentize($c-grey-blue--dark, 0.93);
+            border: 1px solid transparentize($c-blue--darker, 0.9);
+            border-radius: $b-radius;
+            box-sizing: border-box;
+            color: $c-grey--dark;
+            display: block;
+            font-family: inherit;
+            font-size: 0.8125rem;
+            padding: 1ex;
+            width: 100%;
+
+            &::placeholder {
+                color: $c-blue--darker;
+                opacity: 0.5;
+            }
+
+            &:focus {
+                border-color: $c-blue;
+                outline: none;
+            }
+        }
+    }
+
+    &__content {
+        max-height: 300px;
+        overflow-y: auto;
+        padding: 0 1rem;
+    }
+
+    &__items {
+        @include list-reset;
+    }
+
+    &__item {
+        padding: 0.1875rem 0;
+
+        &--category {
+            border-bottom: 1px solid $c-grey--light;
+            padding: 0.75rem 0;
+
+            &:last-child {
+                border-bottom: 0;
+            }
+        }
+    }
+
+    &__category {
+        color: $c-grey-blue--dark;
+        font-size: 0.875rem;
+        font-weight: $weight-bold;
+        margin: 0 0 0.25rem;
+    }
+
+    &__link {
+        color: $c-grey-blue--darker;
+        display: block;
+        font-size: 0.75rem;
+        font-weight: $weight-normal;
+        padding-left: 1rem;
+        position: relative;
+        transition: color 0.2s;
+
+        &:hover,
+        &:focus {
+            color: $c-blue--darker;
+
+            #{ $self }__text {
+                background-position-x: 0;
+                background-size: 100% 1px;
+            }
+        }
+
+        &.is-active {
+            color: $c-blue--darker;
+            font-weight: $weight-bold;
+
+            &::before {
+                @include svg('check', $c-blue--darker);
+
+                display: block;
+                height: 12px;
+                left: 0;
+                line-height: 12px;
+                position: absolute;
+                top: 5px;
+                width: 12px;
+            }
+        }
+    }
+
+    &__text {
+        background: linear-gradient(currentColor, currentColor) no-repeat 100% 100%;
+        background-size: 0 1px;
+        display: inline-block;
+        transition: background-size 0.2s ease-in-out;
+    }
+
+    &__empty {
+        font-size: 0.75rem;
+        margin: 1rem 0;
+    }
+}

--- a/playground/src/scss/components/menu.scss
+++ b/playground/src/scss/components/menu.scss
@@ -164,6 +164,12 @@
             width: 250px;
         }
 
+        &--wide {
+            #{ $self }__dropdown {
+                width: 340px;
+            }
+        }
+
         &--right {
             #{ $self }__dropdown {
                 left: auto;

--- a/playground/src/scss/main.scss
+++ b/playground/src/scss/main.scss
@@ -2,6 +2,7 @@
 @import 'components/columns';
 @import 'components/dropdown';
 @import 'components/editor';
+@import 'components/example-menu';
 @import 'components/header';
 @import 'components/icon';
 @import 'components/menu';


### PR DESCRIPTION
- Make sure config objects are immutable by using DeepFreeze helper because Objec.freeze only is shallow but we need deep because of nested config properties.
- Use lodash deepclone to deep clone workspaces & example because we don't want to edit the original object which did happen before because in js object are reference values. Before this was not an issue because the config was only used for workspaces in the playground, but now it's used for example too so this was a problem now with multiple places editing the original config which should not
 happen.
- Rename hash-params helper to url-params, so we can have helper functions for not just hash params but also search params there
- Move updating hash & updating search params to the url param helper
- On load of page get example params from url and load example (note: if we have both id (saved code) and example in the url: id wins)
- Update searchparams via helper when needed
 - Add example menu component
 - Use Fuzzy search in example menu to filter the array of examples
 - Group the examples by category and sort by category weight
 - Add styling for search menu, input & items

To test: Go to /play. Click on examples. Try the search input and click on an example to test it. The url should update and the example should be loaded

For https://linear.app/usmedia/issue/CUE-227