### PR TITLE
hugo: Add ability to place terminal at bottom of code tabs

### DIFF
--- a/content/examples/shortcodes/code-tabs/en.md
+++ b/content/examples/shortcodes/code-tabs/en.md
@@ -29,7 +29,7 @@ languages:
     name: Norwegian
 {{</* /code-tab */>}}
 
-{{</* code-tab name="TERMINAL" type="terminal" area="top-right" */>}}
+{{</* code-tab name="TERMINAL" type="terminal" area="right" */>}}
 languages.1.name: invalid value "dutch" (does not match =~"^\\p{Lu}"):
     ./schema.cue:3:8
     ./data.yaml:5:12
@@ -68,7 +68,7 @@ languages:
   name: Norwegian
 {{< /code-tab >}}
 
-{{< code-tab name="TERMINAL" type="terminal" area="top-right" >}}
+{{< code-tab name="TERMINAL" type="terminal" area="right" >}}
 languages.1.name: invalid value "dutch" (does not match =~"^\\p{Lu}"):
 ./schema.cue:3:8
 ./data.yaml:5:12
@@ -93,7 +93,9 @@ name
 : required - Name of the tab
 
 area
-: required - Area the tab should be in. Can be one of 'top-left', 'top-right', 'bottom-left' or 'bottom-right'.
+: required - Area the tab should be in. Can be one of 'top', 'left', 'top-left', 'top-right', 'bottom', 'bottom-left', 'right or 'bottom-right'.
+Note: You can either use bottom or bottom-left/bottom-right. You can't combine 'bottom' with another bottom area. Same goes for top, left and right.
+For instance if you have a tab set to 'left' it will file the entire left area and can't be combined with 'top-left' because this will break the layout.
 
 language
 : optional - Code language (for instance yaml or json)
@@ -154,10 +156,10 @@ languages:
   {{< /code-tabs >}}
 
 
-### 1 tab in top-left and 1 tab in bottom-left (1 column, 2 rows)
+### 1 tab in top and 1 tab in bottom (1 column, 2 rows)
 {{< code-tabs >}}
 
-{{< code-tab name="schema.cue" area="top-left" >}}
+{{< code-tab name="schema.cue" area="top" >}}
 #Language: {
 tag:  string
 name: =~"^\\p{Lu}" // Must start with an uppercase letter.
@@ -165,7 +167,7 @@ name: =~"^\\p{Lu}" // Must start with an uppercase letter.
 languages: [...#Language]
 {{< /code-tab >}}
 
-{{< code-tab name="data.yaml" language="yaml" area="bottom-left" >}}
+{{< code-tab name="data.yaml" language="yaml" area="bottom" >}}
 languages:
 - tag: en
   name: English
@@ -176,7 +178,7 @@ languages:
 {{< /code-tab >}}
   {{< /code-tabs >}}
 
-### 2 tabs in top-left, 1 in bottom-left and 1 in top-right
+### 2 tabs in top-left, 1 in bottom-left and 1 in right
 
 {{< code-tabs >}}
 
@@ -208,7 +210,7 @@ languages:
   name: Norwegian
 {{< /code-tab >}}
 
-{{< code-tab name="TERMINAL" type="terminal" area="top-right" >}}
+{{< code-tab name="TERMINAL" type="terminal" area="right" >}}
 languages.1.name: invalid value "dutch" (does not match =~"^\\p{Lu}"):
 ./schema.cue:3:8
 ./data.yaml:5:12
@@ -216,7 +218,49 @@ languages.1.name: invalid value "dutch" (does not match =~"^\\p{Lu}"):
 
 {{< /code-tabs >}}
 
-### 1 tab in top-left, 1 in top-right and 1 in bottom-right
+
+### 2 tabs in top-left, 1 in top-right, 1 in bottom
+
+{{< code-tabs >}}
+
+{{< code-tab name="schema.cue" area="top-left" >}}
+#Language: {
+tag:  string
+name: =~"^\\p{Lu}" // Must start with an uppercase letter.
+}
+languages: [...#Language]
+{{< /code-tab >}}
+
+{{< code-tab name="data.yaml" language="yaml" area="top-left" >}}
+languages:
+- tag: en
+  name: English
+- tag: nl
+  name: dutch
+- tag: no
+  name: Norwegian
+  {{< /code-tab >}}
+
+{{< code-tab name="data.yaml" language="yaml" area="top-right" >}}
+languages:
+- tag: en
+  name: English
+- tag: nl
+  name: dutch
+- tag: no
+  name: Norwegian
+  {{< /code-tab >}}
+
+{{< code-tab name="TERMINAL" type="terminal" area="bottom" >}}
+languages.1.name: invalid value "dutch" (does not match =~"^\\p{Lu}"):
+./schema.cue:3:8
+./data.yaml:5:12
+{{< /code-tab >}}
+
+{{< /code-tabs >}}
+
+
+### 1 tab in left, 1 in top-right and 1 in bottom-right
 
 {{< code-tabs >}}
 
@@ -238,7 +282,7 @@ languages:
   name: Norwegian
 {{< /code-tab >}}
 
-{{< code-tab name="TERMINAL" type="terminal" area="top-left" >}}
+{{< code-tab name="TERMINAL" type="terminal" area="left" >}}
 languages.1.name: invalid value "dutch" (does not match =~"^\\p{Lu}"):
 ./schema.cue:3:8
 ./data.yaml:5:12

--- a/hugo/assets/scss/components/code-tabs.scss
+++ b/hugo/assets/scss/components/code-tabs.scss
@@ -35,6 +35,16 @@
                 grid-column: span 2;
             }
 
+            &--top {
+                grid-area: topLeft;
+                grid-column: span 2;
+            }
+
+            &--bottom {
+                grid-area: bottomLeft;
+                grid-column: span 2;
+            }
+
             &--left {
                 border-bottom: 0;
                 grid-area: topLeft;
@@ -51,38 +61,22 @@
 
             &--top-left {
                 grid-area: topLeft;
-
-                &:nth-last-child(2) {
-                    grid-column: span 2;
-                }
             }
 
             &--bottom-left {
                 border-bottom: 0;
                 grid-area: bottomLeft;
-
-                &:last-child {
-                    grid-column: span 2;
-                }
             }
 
             &--top-right {
                 border-left: 2px solid var(--pre-border-color, $c-grey-blue);
                 grid-area: topRight;
-
-                &:first-child {
-                    grid-column: span 2;
-                }
             }
 
             &--bottom-right {
                 border-bottom: 0;
                 border-left: 2px solid var(--pre-border-color, $c-grey-blue);
                 grid-area: bottomRight;
-
-                &:nth-child(2) {
-                    grid-column: span 2;
-                }
             }
         }
     }

--- a/hugo/content/en/examples/shortcodes/code-tabs/index.md
+++ b/hugo/content/en/examples/shortcodes/code-tabs/index.md
@@ -29,7 +29,7 @@ languages:
     name: Norwegian
 {{</* /code-tab */>}}
 
-{{</* code-tab name="TERMINAL" type="terminal" area="top-right" */>}}
+{{</* code-tab name="TERMINAL" type="terminal" area="right" */>}}
 languages.1.name: invalid value "dutch" (does not match =~"^\\p{Lu}"):
     ./schema.cue:3:8
     ./data.yaml:5:12
@@ -68,7 +68,7 @@ languages:
   name: Norwegian
 {{< /code-tab >}}
 
-{{< code-tab name="TERMINAL" type="terminal" area="top-right" >}}
+{{< code-tab name="TERMINAL" type="terminal" area="right" >}}
 languages.1.name: invalid value "dutch" (does not match =~"^\\p{Lu}"):
 ./schema.cue:3:8
 ./data.yaml:5:12
@@ -93,7 +93,9 @@ name
 : required - Name of the tab
 
 area
-: required - Area the tab should be in. Can be one of 'top-left', 'top-right', 'bottom-left' or 'bottom-right'.
+: required - Area the tab should be in. Can be one of 'top', 'left', 'top-left', 'top-right', 'bottom', 'bottom-left', 'right or 'bottom-right'.
+Note: You can either use bottom or bottom-left/bottom-right. You can't combine 'bottom' with another bottom area. Same goes for top, left and right.
+For instance if you have a tab set to 'left' it will file the entire left area and can't be combined with 'top-left' because this will break the layout.
 
 language
 : optional - Code language (for instance yaml or json)
@@ -154,10 +156,10 @@ languages:
   {{< /code-tabs >}}
 
 
-### 1 tab in top-left and 1 tab in bottom-left (1 column, 2 rows)
+### 1 tab in top and 1 tab in bottom (1 column, 2 rows)
 {{< code-tabs >}}
 
-{{< code-tab name="schema.cue" area="top-left" >}}
+{{< code-tab name="schema.cue" area="top" >}}
 #Language: {
 tag:  string
 name: =~"^\\p{Lu}" // Must start with an uppercase letter.
@@ -165,7 +167,7 @@ name: =~"^\\p{Lu}" // Must start with an uppercase letter.
 languages: [...#Language]
 {{< /code-tab >}}
 
-{{< code-tab name="data.yaml" language="yaml" area="bottom-left" >}}
+{{< code-tab name="data.yaml" language="yaml" area="bottom" >}}
 languages:
 - tag: en
   name: English
@@ -176,7 +178,7 @@ languages:
 {{< /code-tab >}}
   {{< /code-tabs >}}
 
-### 2 tabs in top-left, 1 in bottom-left and 1 in top-right
+### 2 tabs in top-left, 1 in bottom-left and 1 in right
 
 {{< code-tabs >}}
 
@@ -208,7 +210,7 @@ languages:
   name: Norwegian
 {{< /code-tab >}}
 
-{{< code-tab name="TERMINAL" type="terminal" area="top-right" >}}
+{{< code-tab name="TERMINAL" type="terminal" area="right" >}}
 languages.1.name: invalid value "dutch" (does not match =~"^\\p{Lu}"):
 ./schema.cue:3:8
 ./data.yaml:5:12
@@ -216,7 +218,49 @@ languages.1.name: invalid value "dutch" (does not match =~"^\\p{Lu}"):
 
 {{< /code-tabs >}}
 
-### 1 tab in top-left, 1 in top-right and 1 in bottom-right
+
+### 2 tabs in top-left, 1 in top-right, 1 in bottom
+
+{{< code-tabs >}}
+
+{{< code-tab name="schema.cue" area="top-left" >}}
+#Language: {
+tag:  string
+name: =~"^\\p{Lu}" // Must start with an uppercase letter.
+}
+languages: [...#Language]
+{{< /code-tab >}}
+
+{{< code-tab name="data.yaml" language="yaml" area="top-left" >}}
+languages:
+- tag: en
+  name: English
+- tag: nl
+  name: dutch
+- tag: no
+  name: Norwegian
+  {{< /code-tab >}}
+
+{{< code-tab name="data.yaml" language="yaml" area="top-right" >}}
+languages:
+- tag: en
+  name: English
+- tag: nl
+  name: dutch
+- tag: no
+  name: Norwegian
+  {{< /code-tab >}}
+
+{{< code-tab name="TERMINAL" type="terminal" area="bottom" >}}
+languages.1.name: invalid value "dutch" (does not match =~"^\\p{Lu}"):
+./schema.cue:3:8
+./data.yaml:5:12
+{{< /code-tab >}}
+
+{{< /code-tabs >}}
+
+
+### 1 tab in left, 1 in top-right and 1 in bottom-right
 
 {{< code-tabs >}}
 
@@ -238,7 +282,7 @@ languages:
   name: Norwegian
 {{< /code-tab >}}
 
-{{< code-tab name="TERMINAL" type="terminal" area="top-left" >}}
+{{< code-tab name="TERMINAL" type="terminal" area="left" >}}
 languages.1.name: invalid value "dutch" (does not match =~"^\\p{Lu}"):
 ./schema.cue:3:8
 ./data.yaml:5:12

--- a/hugo/layouts/shortcodes/code-tabs.html
+++ b/hugo/layouts/shortcodes/code-tabs.html
@@ -2,49 +2,93 @@
 
 {{- $groupId := .Get "groupId" | default "default" -}}
 {{- $height := .Get "height" | default false -}}
+{{- $tabsTop := .Scratch.Get "tabs-top" -}}
 {{- $tabsTopLeft := .Scratch.Get "tabs-top-left" -}}
 {{- $tabsTopRight := .Scratch.Get "tabs-top-right" -}}
+{{- $tabsBottom := .Scratch.Get "tabs-bottom" -}}
 {{- $tabsBottomLeft := .Scratch.Get "tabs-bottom-left" -}}
 {{- $tabsBottomRight := .Scratch.Get "tabs-bottom-right" -}}
+{{- $tabsLeft := .Scratch.Get "tabs-left" -}}
+{{- $tabsRight := .Scratch.Get "tabs-right" -}}
+
 
 <div class="code-tabs"{{ if $height }} style="height: {{ $height }}px"{{ end }}>
+    {{ if $tabsTop }}
+        <div class="code-tabs__item code-tabs__item--top">
+            {{ partial "tabs.html" (dict
+            "groupId" $groupId
+            "tabs" $tabsTop
+            "modifier" "code"
+            ) }}
+        </div>
+    {{ end }}
+
+    {{ if $tabsLeft }}
+        <div class="code-tabs__item code-tabs__item--left">
+            {{ partial "tabs.html" (dict
+            "groupId" $groupId
+            "tabs" $tabsLeft
+            "modifier" "code"
+            ) }}
+        </div>
+    {{ end }}
+
     {{ if $tabsTopLeft }}
-        {{- $modifier := cond (not $tabsBottomLeft) "code-tabs__item--left" "code-tabs__item--top-left" -}}
-        <div class="code-tabs__item {{ $modifier }}">
+        <div class="code-tabs__item code-tabs__item--top-left">
             {{ partial "tabs.html" (dict
-            "groupId" $groupId
-            "tabs" $tabsTopLeft
-            "modifier" "code"
+                "groupId" $groupId
+                "tabs" $tabsTopLeft
+                "modifier" "code"
             ) }}
         </div>
     {{ end }}
+
     {{ if $tabsBottomLeft }}
-        {{- $modifier := cond (not $tabsTopLeft) "code-tabs__item--left" "code-tabs__item--bottom-left" -}}
-        <div class="code-tabs__item {{ $modifier }}">
+        <div class="code-tabs__item code-tabs__item--bottom-left">
+            {{ partial "tabs.html" (dict
+                "groupId" $groupId
+                "tabs" $tabsBottomLeft
+                "modifier" "code"
+            ) }}
+        </div>
+    {{ end }}
+
+    {{ if $tabsRight }}
+        <div class="code-tabs__item code-tabs__item--right">
             {{ partial "tabs.html" (dict
             "groupId" $groupId
-            "tabs" $tabsBottomLeft
+            "tabs" $tabsRight
             "modifier" "code"
             ) }}
         </div>
     {{ end }}
+
     {{ if $tabsTopRight }}
-        {{- $modifier := cond (not $tabsBottomRight) "code-tabs__item--right" "code-tabs__item--top-right" -}}
-        <div class="code-tabs__item {{ $modifier }}">
+        <div class="code-tabs__item code-tabs__item--top-right">
             {{ partial "tabs.html" (dict
-            "groupId" $groupId
-            "tabs" $tabsTopRight
-            "modifier" "code"
+                "groupId" $groupId
+                "tabs" $tabsTopRight
+                "modifier" "code"
             ) }}
         </div>
     {{ end }}
+
     {{ if $tabsBottomRight }}
-        {{- $modifier := cond (not $tabsTopRight) "code-tabs__item--right" "code-tabs__item--bottom-right" -}}
-        <div class="code-tabs__item {{ $modifier }}">
+        <div class="code-tabs__item code-tabs__item--bottom-right">
             {{ partial "tabs.html" (dict
-            "groupId" $groupId
-            "tabs" $tabsBottomRight
-            "modifier" "code"
+                "groupId" $groupId
+                "tabs" $tabsBottomRight
+                "modifier" "code"
+            ) }}
+        </div>
+    {{ end }}
+
+    {{ if $tabsBottom }}
+        <div class="code-tabs__item code-tabs__item--bottom">
+            {{ partial "tabs.html" (dict
+                "groupId" $groupId
+                "tabs" $tabsBottom
+                "modifier" "code"
             ) }}
         </div>
     {{ end }}


### PR DESCRIPTION
- Add options for 'bottom', 'top', 'left' and 'right'.
- Remove the conditionals to determine of for instance a topLeft column should stretch over the entire column or/and row. This does not work together with the wish to determine this ourselves. From now on you have to define 'top' if you want te tab to fill the entire top. Same goes for bottom, left and right.

Note: This will require some changes in the pre-processor logic do termine the
 right 'area' for code-tabs.

To test: /examples/shortcodes/code-tabs/

For https://linear.app/usmedia/issue/CUE-320