### PR TITLE
hugo: add search shortcode

### DIFF
--- a/content/blog/_en.html
+++ b/content/blog/_en.html
@@ -1,5 +1,5 @@
 ---
-title: "Blog overview"
-description: "Blog overview description."
+title: "Blog"
+description: "CUE blogs"
 layout: list
 ---

--- a/content/examples/_en.html
+++ b/content/examples/_en.html
@@ -133,6 +133,11 @@ description: "View examples on how to use certain possible elements of the theme
 
                     <ul class="nav__list">
                         <li class="nav__item">
+                            <a class="nav__link" href="/examples/shortcodes/search/">
+                                <span class="nav__text">Search</span>
+                            </a>
+                        </li>
+                        <li class="nav__item">
                             <a class="nav__link" href="/examples/shortcodes/spinner/">
                                 <span class="nav__text">Spinner</span>
                             </a>

--- a/content/examples/shortcodes/search/en.md
+++ b/content/examples/shortcodes/search/en.md
@@ -1,0 +1,23 @@
+---
+title: Search
+weight: 25
+---
+
+With this shortcode you can embed a search results widget on the page.
+
+## Example
+
+```
+{{</* search contentType="How-to Guides" showContentTypes=false */>}}
+```
+
+{{< search contentType="How-to Guides" showContentTypes=false >}}
+
+
+## Attributes
+
+contentType
+: required when showContentTypes is false - Enter the preselected content type
+
+showContentTypes
+: optional - If set to false the content type dropdown won't show

--- a/content/examples/shortcodes/search/page.cue
+++ b/content/examples/shortcodes/search/page.cue
@@ -1,0 +1,3 @@
+package site
+
+"examples": "shortcodes": "search": {}

--- a/hugo/assets/scss/components/search.scss
+++ b/hugo/assets/scss/components/search.scss
@@ -1,3 +1,4 @@
+@import '../config/colors';
 @import '../config/sizes';
 @import '../config/typography';
 @import '../mixins/screen';
@@ -34,6 +35,16 @@
         font-size: 0.875rem;
         font-weight: $weight-bold;
         margin: 0;
+    }
+
+    &--widget {
+        background: $c-blue--lighter;
+        border-radius: $b-radius;
+        padding: 2.5rem $p-gutter 2rem;
+
+        .searchbar__logo {
+            margin-top: -28px;
+        }
     }
 
     @include screen(600px) {

--- a/hugo/assets/scss/components/searchbar.scss
+++ b/hugo/assets/scss/components/searchbar.scss
@@ -146,7 +146,6 @@
     @include screen($screen-simple) {
         &__logo {
             margin: -42px $p-gutter 1rem auto;
-
         }
     }
 

--- a/hugo/assets/ts/helpers/search.ts
+++ b/hugo/assets/ts/helpers/search.ts
@@ -59,6 +59,13 @@ export const queryToUrlParams = (query: ParsedQuery): string => {
 };
 
 export const parseQuery = (query: string): ParsedQuery => {
+    if (!query) {
+        return {
+            cleanQuery: '',
+            facets: {},
+        };
+    }
+
     let cleanQuery = query;
 
     const facets: SearchFacets = {

--- a/hugo/assets/ts/widgets/search-autocomplete.ts
+++ b/hugo/assets/ts/widgets/search-autocomplete.ts
@@ -20,6 +20,7 @@ export class SearchAutocomplete extends BaseWidget {
     private readonly searchbarSize: string;
     private querySuggestionsPlugin: AutocompletePlugin<AutocompleteQuerySuggestionsHit, undefined>;
     private autocomplete: AutocompleteApi<BaseItem>;
+    private readonly placeholder: string;
 
     constructor(element: HTMLElement) {
         super(element);
@@ -28,6 +29,7 @@ export class SearchAutocomplete extends BaseWidget {
         this.suggestionsClient = algoliasearch('5LXFM0O81Q', '6f93ecdc1bf190af31a69b04a21a38b8');
         this.searchType = this.element.dataset.searchAutocomplete || '';
         this.searchbarSize = this.element.dataset.searchbarSize;
+        this.placeholder = this.element.dataset.searchbarPlaceholder ?? '';
     }
 
     public static registerWidget(): void {
@@ -120,6 +122,7 @@ export class SearchAutocomplete extends BaseWidget {
             plugins: [this.querySuggestionsPlugin],
             detachedMediaQuery: '(max-width: 1023px)',
             openOnFocus: this.searchType === 'results',
+            placeholder: this.placeholder,
             getSources() {
                 return [{
                     sourceId: 'documentation',
@@ -210,7 +213,11 @@ export class SearchAutocomplete extends BaseWidget {
                 },
             },
             onSubmit(params: OnSubmitParams<BaseItem>) {
-                window.location.href = `/search?q=${ params.state.query }`;
+                if (searchType === 'results') {
+                    window.location.href = `?q=${ params.state.query }`;
+                } else {
+                    window.location.href = `/search?q=${ params.state.query }`;
+                }
             },
             classNames: {
                 detachedCancelButton: '',

--- a/hugo/content/en/blog/_index.html
+++ b/hugo/content/en/blog/_index.html
@@ -1,5 +1,5 @@
 ---
-title: "Blog overview"
-description: "Blog overview description."
+title: "Blog"
+description: "CUE blogs"
 layout: list
 ---

--- a/hugo/content/en/examples/_index.html
+++ b/hugo/content/en/examples/_index.html
@@ -133,6 +133,11 @@ description: "View examples on how to use certain possible elements of the theme
 
                     <ul class="nav__list">
                         <li class="nav__item">
+                            <a class="nav__link" href="/examples/shortcodes/search/">
+                                <span class="nav__text">Search</span>
+                            </a>
+                        </li>
+                        <li class="nav__item">
                             <a class="nav__link" href="/examples/shortcodes/spinner/">
                                 <span class="nav__text">Spinner</span>
                             </a>

--- a/hugo/content/en/examples/shortcodes/search/index.md
+++ b/hugo/content/en/examples/shortcodes/search/index.md
@@ -1,0 +1,23 @@
+---
+title: Search
+weight: 25
+---
+
+With this shortcode you can embed a search results widget on the page.
+
+## Example
+
+```
+{{</* search contentType="How-to Guides" showContentTypes=false */>}}
+```
+
+{{< search contentType="How-to Guides" showContentTypes=false >}}
+
+
+## Attributes
+
+contentType
+: required when showContentTypes is false - Enter the preselected content type
+
+showContentTypes
+: optional - If set to false the content type dropdown won't show

--- a/hugo/i18n/en.toml
+++ b/hugo/i18n/en.toml
@@ -89,6 +89,8 @@ other = "What are you looking for?"
 other = "documents found"
 [search_filters_title]
 other = "Filters"
+[search_placeholder]
+other = "Search in {{ .contentType }}"
 
 [search_tags_title]
 other = "Tags"

--- a/hugo/layouts/_default/search.html
+++ b/hugo/layouts/_default/search.html
@@ -1,18 +1,4 @@
 {{ define "main" }}
-    {{ $contentTypes := slice }}
-    {{ $pages := $.Site.Sections.ByWeight -}}
-
-    {{ range $page := $pages }}
-        {{ if eq $page.Type "docs" }}
-            {{ $docs := (union $page.Pages $page.Sections).ByWeight  -}}
-            {{ range $doc := $docs }}
-                {{ $contentTypes = $contentTypes | append (dict "name" $doc.Title) }}
-            {{ end }}
-        {{ else if  (not (eq $page.Type "examples")) }}
-            {{ $contentTypes = $contentTypes | append (dict "name" $page.Title) }}
-        {{ end }}
-    {{ end }}
-
     <section class="section section--blue section--search">
         <header class="section__header">
             <div class="section__content">
@@ -20,39 +6,8 @@
             </div>
         </header>
         <div class="section__body">
-            <div class="section__content" data-search-results data-tags="{{ .Site.Params.tags | jsonify }}">
-                <div class="search">
-                    <div class="search__bar">
-                        {{- partial "searchbar.html" (dict
-                            "type" "results"
-                            "inputId" "searchbar"
-                        ) -}}
-                    </div>
-                    <div class="search__options">
-                        <div class="search__amount is-hidden">
-                            {{ T "search_results" }}
-                        </div>
-
-                        <div class="search__filters">
-                            <p class="search__filters-title"> {{ T "search_filters_title" }}</p>
-
-                            {{- partial "filter.html" (dict
-                                "cssClass" "search__filter"
-                                "translationKey" "tags"
-                                "name" "tags"
-                                "filters" .Site.Params.tags
-                            ) -}}
-
-                            {{- partial "filter.html" (dict
-                                "cssClass" "search__filter"
-                                "translationKey" "contentType"
-                                "name" "contentType"
-                                "filters" $contentTypes
-                            ) -}}
-                        </div>
-                    </div>
-                    <ul class="search__results list list--archive"></ul>
-                </div>
+            <div class="section__content">
+                {{- partial "search"  (dict "context" .) -}}
             </div>
         </div>
     </section>

--- a/hugo/layouts/partials/search.html
+++ b/hugo/layouts/partials/search.html
@@ -1,0 +1,61 @@
+{{ $context := .context }}
+{{ $showContentTypes := .showContentTypes | default true }}
+{{ $contentTypes := slice }}
+{{ $contentType := .contentType | default "" }}
+{{ $type := .type | default "full" }}
+{{ $placeholder := (T "search_placeholder" .) }}
+
+{{ with $context }}
+    {{ if $showContentTypes }}
+        {{ $pages := .Site.Sections.ByWeight -}}
+
+        {{ range $page := $pages }}
+            {{ if eq $page.Type "docs" }}
+                {{ $docs := (union $page.Pages $page.Sections).ByWeight  -}}
+                {{ range $doc := $docs }}
+                    {{ $contentTypes = $contentTypes | append (dict "name" $doc.Title) }}
+                {{ end }}
+            {{ else if  (not (eq $page.Type "examples")) }}
+                {{ $contentTypes = $contentTypes | append (dict "name" $page.Title) }}
+            {{ end }}
+        {{ end }}
+    {{ end }}
+
+    <div class="search{{ if eq $type "widget" }} search--widget{{ end }}" data-search-results data-tags="{{ .Site.Params.tags | jsonify }}">
+        <div class="search__bar">
+            {{- partial "searchbar.html" (dict
+                "type" "results"
+                "inputId" "searchbar"
+                "placeholder" $placeholder
+            ) -}}
+        </div>
+        <div class="search__options">
+            <div class="search__amount is-hidden">
+                {{ T "search_results" }}
+            </div>
+
+            <div class="search__filters">
+                <p class="search__filters-title"> {{ T "search_filters_title" }}</p>
+
+                {{- partial "filter.html" (dict
+                    "cssClass" "search__filter"
+                    "translationKey" "tags"
+                    "name" "tags"
+                    "filters" .Site.Params.tags
+                ) -}}
+
+                {{ if $showContentTypes }}
+                    {{- partial "filter.html" (dict
+                        "cssClass" "search__filter"
+                        "translationKey" "contentType"
+                        "name" "contentType"
+                        "filters" $contentTypes
+                    ) -}}
+                {{ else }}
+                    <input type="hidden" name="facet-contentType" value="{{ $contentType }}">
+                {{ end }}
+            </div>
+        </div>
+        <ul class="search__results list list--archive"></ul>
+    </div>
+{{ end }}

--- a/hugo/layouts/partials/searchbar.html
+++ b/hugo/layouts/partials/searchbar.html
@@ -2,9 +2,12 @@
 {{ $inputId := .id | default "searchbar"}}
 {{ $modifier := .modifier | default "" }}
 {{ $type := .type | default "" }}
+{{ $placeholder := .placeholder | default "" }}
 
 <div data-search-autocomplete="{{ $type }}"
-     data-searchbar-size="{{ if not (eq $type "results") }}small{{ end }}">
+     data-searchbar-size="{{ if not (eq $type "results") }}small{{ end }}"
+     data-searchbar-placeholder="{{ $placeholder }}"
+>
     <div class="searchbar__logo">
         {{ with resources.Get "svg/algolia-search.svg" }}{{ ( . | minify ).Content | safeHTML }}{{ end }}
     </div>

--- a/hugo/layouts/shortcodes/search.html
+++ b/hugo/layouts/shortcodes/search.html
@@ -1,0 +1,9 @@
+{{- $contentType := .Get "contentType" | default "" -}}
+{{- $showContentTypes := .Get "showContentTypes" | default true -}}
+
+{{- partial "search"  (dict
+    "type" "widget"
+    "contentType" $contentType
+    "showContentTypes" $showContentTypes
+    "context" .
+) -}}

--- a/hugo/package-lock.json
+++ b/hugo/package-lock.json
@@ -15,10 +15,12 @@
         "algoliasearch": "4.17.0",
         "atomic-algolia": "0.3.19",
         "fuse.js": "6.6.2",
+        "lodash.merge": "4.6.2",
         "mathjax": "3.2.2",
         "mermaid": "9.2.2"
       },
       "devDependencies": {
+        "@types/lodash.merge": "4.6.7",
         "@types/youtube": "0.0.47",
         "@typescript-eslint/eslint-plugin": "5.54.1",
         "@typescript-eslint/parser": "5.54.1",
@@ -2212,6 +2214,21 @@
       "resolved": "https://registry.npmjs.org/@types/json5/-/json5-0.0.29.tgz",
       "integrity": "sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==",
       "dev": true
+    },
+    "node_modules/@types/lodash": {
+      "version": "4.14.197",
+      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.197.tgz",
+      "integrity": "sha512-BMVOiWs0uNxHVlHBgzTIqJYmj+PgCo4euloGF+5m4okL3rEYzM2EEv78mw8zWSMM57dM7kVIgJ2QDvwHSoCI5g==",
+      "dev": true
+    },
+    "node_modules/@types/lodash.merge": {
+      "version": "4.6.7",
+      "resolved": "https://registry.npmjs.org/@types/lodash.merge/-/lodash.merge-4.6.7.tgz",
+      "integrity": "sha512-OwxUJ9E50gw3LnAefSHJPHaBLGEKmQBQ7CZe/xflHkyy/wH2zVyEIAKReHvVrrn7zKdF58p16We9kMfh7v0RRQ==",
+      "dev": true,
+      "dependencies": {
+        "@types/lodash": "*"
+      }
     },
     "node_modules/@types/minimist": {
       "version": "1.2.2",
@@ -6071,8 +6088,7 @@
     "node_modules/lodash.merge": {
       "version": "4.6.2",
       "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
-      "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
-      "dev": true
+      "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ=="
     },
     "node_modules/lodash.truncate": {
       "version": "4.4.2",
@@ -10057,6 +10073,21 @@
       "integrity": "sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==",
       "dev": true
     },
+    "@types/lodash": {
+      "version": "4.14.197",
+      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.197.tgz",
+      "integrity": "sha512-BMVOiWs0uNxHVlHBgzTIqJYmj+PgCo4euloGF+5m4okL3rEYzM2EEv78mw8zWSMM57dM7kVIgJ2QDvwHSoCI5g==",
+      "dev": true
+    },
+    "@types/lodash.merge": {
+      "version": "4.6.7",
+      "resolved": "https://registry.npmjs.org/@types/lodash.merge/-/lodash.merge-4.6.7.tgz",
+      "integrity": "sha512-OwxUJ9E50gw3LnAefSHJPHaBLGEKmQBQ7CZe/xflHkyy/wH2zVyEIAKReHvVrrn7zKdF58p16We9kMfh7v0RRQ==",
+      "dev": true,
+      "requires": {
+        "@types/lodash": "*"
+      }
+    },
     "@types/minimist": {
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/@types/minimist/-/minimist-1.2.2.tgz",
@@ -12891,8 +12922,7 @@
     "lodash.merge": {
       "version": "4.6.2",
       "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
-      "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
-      "dev": true
+      "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ=="
     },
     "lodash.truncate": {
       "version": "4.4.2",

--- a/hugo/package.json
+++ b/hugo/package.json
@@ -12,10 +12,12 @@
     "algoliasearch": "4.17.0",
     "atomic-algolia": "0.3.19",
     "fuse.js": "6.6.2",
+    "lodash.merge": "4.6.2",
     "mathjax": "3.2.2",
     "mermaid": "9.2.2"
   },
   "devDependencies": {
+    "@types/lodash.merge": "4.6.7",
     "@types/youtube": "0.0.47",
     "@typescript-eslint/eslint-plugin": "5.54.1",
     "@typescript-eslint/parser": "5.54.1",


### PR DESCRIPTION
- Add search shortcode
- Move search to a partial to be able to reuse it
- Add styling for search--widget
- Add logic for hidden field is contentTypes dropdown is hidden
- If content type is filled in: use this as placeholder in the searchbar
- Remove check on empty query because we also want to search when no query is
filled in but facets are set
- Fix scoping issue for search ts (checking within element instead of
document)
- Change handle submit to use current page when type is results
- Add example page
- Fix issue with blog having been renamed to 'Blog overview' and because it's
a list page this was also renamed in the search results and filters

To test: examples/shortcodes/search

For https://linear.app/usmedia/issue/CUE-283