### PR TITLE
hugo: Add option to hide the section-index on a docs overview page

### DIFF
--- a/hugo/layouts/docs/list.html
+++ b/hugo/layouts/docs/list.html
@@ -8,7 +8,10 @@
 
                     <div class="article__content">
                         {{ .Content }}
-                        {{ partial "paging/section-index.html" . }}
+
+                        {{ if ne .Params.index_hide true }}
+                            {{ partial "paging/section-index.html" . }}
+                        {{ end }}
                     </div>
 
                     <footer class="article__footer">


### PR DESCRIPTION
- Added param 'index_hide' to the front-matter
- When param index_hide is set to to true: don't show the section-index

To test:
- Add `index_hide: true` to the front-matter of a docs overview page
- I didn't add to any of the current pages because I don't want to mess with the content.

For https://linear.app/usmedia/issue/CUE-334