### PR TITLE
hugo: Fix search results bug when tag is not found in tag config

### DIFF
--- a/hugo/assets/ts/widgets/search-results.ts
+++ b/hugo/assets/ts/widgets/search-results.ts
@@ -98,7 +98,10 @@ export class SearchResults extends BaseWidget {
     public createTeaser(teaser: Teaser): string {
         let tags = null;
         if (teaser.tags && teaser.tags.length) {
-            tags = teaser.tags.map(tagString => this.tags.find(tag => tag.name === tagString));
+            tags = teaser.tags.map(tagString => {
+                const fullTag = this.tags.find(tag => tag.name === tagString);
+                return fullTag ?? { name: tagString, color: 'blue' };
+            });
         }
 
         return `


### PR DESCRIPTION
- If a tag on a page is not found in the tag config: show it anyway using the tag-string as name and default color 'blue'

To test: Go to /search and search for 'yaml'. Search results show again and the tag 'yaml' is displayed with the default color blue.

For https://linear.app/usmedia/issue/CUE-336