### PR TITLE
hugo: inject commit hash into hugo template

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,7 @@ node_modules
 /hugo/.hugo_build.lock
 /hugo/static/playground/
 /hugo/.env
+/hugo/data/Repository.json
 
 # Well-known location for go binaries
 /.gobin

--- a/_scripts/gitWriteHash.bash
+++ b/_scripts/gitWriteHash.bash
@@ -1,0 +1,10 @@
+#/usr/bin/env bash
+
+set -eu
+
+revhash=$(git rev-parse HEAD)
+
+# Create hugo/data directory if it doesn't exist
+mkdir -p hugo/data
+
+echo "{\"Revision\": \"$revhash\"}" > hugo/data/Repository.json

--- a/_scripts/runPreprocessor.bash
+++ b/_scripts/runPreprocessor.bash
@@ -24,6 +24,9 @@ then
 	export PREPROCESSOR_NOWRITECACHE="true"
 fi
 
+# Write current commit revision to hugo data file
+bash _scripts/gitWriteHash.bash
+
 GOBIN=$PWD/.gobin go install -trimpath -buildvcs=false ./internal/cmd/preprocessor
 
 exec $PWD/.gobin/preprocessor "$@"

--- a/hugo/layouts/partials/site/footer.html
+++ b/hugo/layouts/partials/site/footer.html
@@ -1,5 +1,5 @@
 {{ $baseUrl := urls.Parse $.Site.Params.Baseurl }}
-{{ $versionCommit := print $.Site.Params.github_repo "/commit/" .GitInfo.Hash }}
+{{ $versionCommit := print $.Site.Params.github_repo "/commit/" .Site.Data.Repository.Revision }}
 {{ $issueBody := (print
     "### What page were you looking at?\n\n"
     .Permalink "\n\n"


### PR DESCRIPTION
This implements a fix for https://github.com/cue-lang/cue/issues/2581

The "Report an Issue" link used the hugo provided `.GitInfo.Hash` variable which gave the commit of the last change that modified that specific page. This change instead writes the HEAD repository hash to a hugo data file that can be referenced in templates.

Injection is implemented as a bash script that is run as part of the preprocessor flow.

Tested correct generation in both hugo build and serve workflows.