### PR TITLE
Hugo: add cards shortcode

### DIFF
--- a/content/examples/_en.html
+++ b/content/examples/_en.html
@@ -64,6 +64,11 @@ description: "View examples on how to use certain possible elements of the theme
                             </a>
                         </li>
                         <li class="nav__item">
+                            <a class="nav__link" href="/examples/shortcodes/cards/">
+                                <span class="nav__text">Cards</span>
+                            </a>
+                        </li>
+                        <li class="nav__item">
                             <a class="nav__link" href="/examples/shortcodes/carousel/">
                                 <span class="nav__text">Carousel</span>
                             </a>

--- a/content/examples/shortcodes/cards/en.md
+++ b/content/examples/shortcodes/cards/en.md
@@ -1,0 +1,66 @@
+---
+title: Cards
+weight: 22
+---
+
+You can use the `{{</* cards */>}}` shortcode in combination with the `{{</* card */>}}` to add cards to your content. Only add "normal" text to the card. Links will not work since the card itself already links to a page.
+
+## Examples
+
+```
+{{</* cards */>}}
+{{</* card href="/docs/introduction/" label="Introduction" title="A great place to start" */>}}
+The Introduction is a quick trip through what's possible with CUE, suitable for newcomers to the language.
+{{</* /card */>}}
+
+{{</* card href="/docs/language-guide/" label="Language Guide" title="A deep dive into CUE" */>}}
+Learning the different aspects of CUE: data, templating, schemas, queries, policy, file organization, and interoperability with other languages/encodings.
+{{</* /card */>}}
+
+{{</* card href="/docs/integrations/" label="Integrations" title="JSON, YAML, Go, Kubernetes, and more" */>}}
+Learn how CUE integrates with a wide ecosystem of formats and tools.
+{{</* /card */>}}
+
+{{</* card href="/docs/tutorial/" label="Tutorials" title="Learn about CUE techniques and tools." */>}}
+The Tutorials section demonstrates different language and tooling features through self-contained lessons, broken down into steps you can safely perform on your own computer.
+{{</* /card */>}}
+
+{{</* card href="/docs/howto/" label="How-to Guides" title="Directions to achieve specific goals." */>}}
+Each of the How-to Guides contains practical steps for completing a task with CUE.
+{{</* /card */>}}
+{{</* /cards */>}}
+```
+
+{{< cards >}}
+{{< card href="/docs/introduction/" label="Introduction" title="A great place to start" >}}
+The Introduction is a quick trip through what's possible with CUE, suitable for newcomers to the language.
+{{< /card >}}
+
+{{< card href="/docs/language-guide/" label="Language Guide" title="A deep dive into CUE" >}}
+Learning the different aspects of CUE: data, templating, schemas, queries, policy, file organization, and interoperability with other languages/encodings.
+{{< /card >}}
+
+{{< card href="/docs/integrations/" label="Integrations" title="JSON, YAML, Go, Kubernetes, and more" >}}
+Learn how CUE integrates with a wide ecosystem of formats and tools.
+{{< /card >}}
+
+{{< card href="/docs/tutorial/" label="Tutorials" title="Learn about CUE techniques and tools." >}}
+The Tutorials section demonstrates different language and tooling features through self-contained lessons, broken down into steps you can safely perform on your own computer.
+{{< /card >}}
+
+{{< card href="/docs/howto/" label="How-to Guides" title="Directions to achieve specific goals." >}}
+Each of the How-to Guides contains practical steps for completing a task with CUE.
+{{< /card >}}
+{{< /cards >}}
+
+
+## Attributes
+
+href
+: optional - makes it possible to link to another page or location on the page.
+
+label
+: optional/required - text for the button. If there is no href, there is no need to add a label. When there is a href, it is highly recommended to add a label.
+
+title
+: optional - adds a title to the card.

--- a/content/examples/shortcodes/cards/page.cue
+++ b/content/examples/shortcodes/cards/page.cue
@@ -1,0 +1,3 @@
+package site
+
+content: examples: shortcodes: "cards": {}

--- a/hugo/assets/scss/components/cards.scss
+++ b/hugo/assets/scss/components/cards.scss
@@ -1,0 +1,103 @@
+@import '../config/colors';
+@import '../config/sizes';
+@import '../mixins/screen';
+@import '../mixins/sr-only';
+@import '../mixins/stretch';
+
+.cards {
+    $self: &;
+
+    --cards-icon-color: #{ $c-blue };
+    --cards-link-border-color: #{ $c-yellow };
+    --cards-border-width: 2px;
+
+    container: cardsContainer / inline-size;
+    margin: 2rem 0;
+
+    &__items {
+        display: grid;
+        gap: $p-gutter;
+    }
+
+    &__item {
+        background-color: $c-blue--lighter;
+        border: 1px solid $c-blue--lighter;
+        border-radius: $b-radius;
+        padding: $p-gutter;
+        position: relative;
+        transition:
+            background-color 0.2s ease-in-out,
+            border 0.2s ease-in-out;
+
+        &:focus,
+        &:hover {
+            background-color: transparentize($c-blue--lighter, 0.4);
+            border: 1px solid transparentize($c-blue--light, 0.8);
+
+            #{ $self }__readmore {
+                --cards-icon-color: #{ $c-yellow };
+            }
+
+            #{ $self }__label {
+                background-position-x: 0;
+                background-size: 100% var(--cards-border-width);
+            }
+        }
+    }
+
+    &__title {
+        margin: 0 0 0.875rem;
+    }
+
+    &__readmore {
+        --link-icon-size: 2rem;
+
+        justify-content: space-between;
+        padding: $p-gutter 0 0 !important; // Overrule .link styling
+        width: 100%;
+    }
+
+    &__label {
+        background: linear-gradient(var(--cards-link-border-color), var(--cards-link-border-color)) no-repeat 100% 100%;
+        background-size: 0 var(--cards-border-width);
+        display: inline-block;
+        position: relative;
+        transition:
+            background-color 0.2s ease-in-out,
+            background-size 0.2s ease-in-out,
+    }
+
+    &__icon {
+        background-color: var(--cards-icon-color);
+        border-radius: $b-radius--round;
+        fill: $c-white;
+        padding: 2px;
+        transition: background-color 0.2s ease-in-out;
+    }
+
+    &__link {
+        @include stretch;
+
+        span {
+            @include sr-only;
+        }
+    }
+
+    @include screen($screen-simple) {
+        &__items {
+            grid-template-columns: 1fr 1fr;
+        }
+
+        &__item {
+            display: grid;
+            grid-template-columns: subgrid;
+            grid-template-rows: auto 1fr auto;
+        }
+    }
+
+    @container cardsContainer (min-width: 900px) {
+        &__items {
+            grid-template-columns: 1fr 1fr 1fr;
+        }
+    }
+}

--- a/hugo/assets/scss/components/link.scss
+++ b/hugo/assets/scss/components/link.scss
@@ -73,10 +73,10 @@
 
     &__icon {
         display: inline-block;
+        height: var(--link-icon-size, 24px);
         margin: 0 0 0 -0.4em;
-        max-height: 24px;
-        max-width: 24px;
         vertical-align: 12px;
+        width: var(--link-icon-size, 24px);
 
         &.icon {
             display: inline-block; // Win from icon styles

--- a/hugo/assets/scss/main.scss
+++ b/hugo/assets/scss/main.scss
@@ -20,6 +20,7 @@
 @import 'components/back-button';
 @import 'components/banner';
 @import 'components/breadcrumb';
+@import 'components/cards';
 @import 'components/carousel';
 @import 'components/code-block';
 @import 'components/code-tabs';

--- a/hugo/content/en/examples/_index.html
+++ b/hugo/content/en/examples/_index.html
@@ -64,6 +64,11 @@ description: "View examples on how to use certain possible elements of the theme
                             </a>
                         </li>
                         <li class="nav__item">
+                            <a class="nav__link" href="/examples/shortcodes/cards/">
+                                <span class="nav__text">Cards</span>
+                            </a>
+                        </li>
+                        <li class="nav__item">
                             <a class="nav__link" href="/examples/shortcodes/carousel/">
                                 <span class="nav__text">Carousel</span>
                             </a>

--- a/hugo/content/en/examples/shortcodes/cards/index.md
+++ b/hugo/content/en/examples/shortcodes/cards/index.md
@@ -1,0 +1,66 @@
+---
+title: Cards
+weight: 22
+---
+
+You can use the `{{</* cards */>}}` shortcode in combination with the `{{</* card */>}}` to add cards to your content. Only add "normal" text to the card. Links will not work since the card itself already links to a page.
+
+## Examples
+
+```
+{{</* cards */>}}
+{{</* card href="/docs/introduction/" label="Introduction" title="A great place to start" */>}}
+The Introduction is a quick trip through what's possible with CUE, suitable for newcomers to the language.
+{{</* /card */>}}
+
+{{</* card href="/docs/language-guide/" label="Language Guide" title="A deep dive into CUE" */>}}
+Learning the different aspects of CUE: data, templating, schemas, queries, policy, file organization, and interoperability with other languages/encodings.
+{{</* /card */>}}
+
+{{</* card href="/docs/integrations/" label="Integrations" title="JSON, YAML, Go, Kubernetes, and more" */>}}
+Learn how CUE integrates with a wide ecosystem of formats and tools.
+{{</* /card */>}}
+
+{{</* card href="/docs/tutorial/" label="Tutorials" title="Learn about CUE techniques and tools." */>}}
+The Tutorials section demonstrates different language and tooling features through self-contained lessons, broken down into steps you can safely perform on your own computer.
+{{</* /card */>}}
+
+{{</* card href="/docs/howto/" label="How-to Guides" title="Directions to achieve specific goals." */>}}
+Each of the How-to Guides contains practical steps for completing a task with CUE.
+{{</* /card */>}}
+{{</* /cards */>}}
+```
+
+{{< cards >}}
+{{< card href="/docs/introduction/" label="Introduction" title="A great place to start" >}}
+The Introduction is a quick trip through what's possible with CUE, suitable for newcomers to the language.
+{{< /card >}}
+
+{{< card href="/docs/language-guide/" label="Language Guide" title="A deep dive into CUE" >}}
+Learning the different aspects of CUE: data, templating, schemas, queries, policy, file organization, and interoperability with other languages/encodings.
+{{< /card >}}
+
+{{< card href="/docs/integrations/" label="Integrations" title="JSON, YAML, Go, Kubernetes, and more" >}}
+Learn how CUE integrates with a wide ecosystem of formats and tools.
+{{< /card >}}
+
+{{< card href="/docs/tutorial/" label="Tutorials" title="Learn about CUE techniques and tools." >}}
+The Tutorials section demonstrates different language and tooling features through self-contained lessons, broken down into steps you can safely perform on your own computer.
+{{< /card >}}
+
+{{< card href="/docs/howto/" label="How-to Guides" title="Directions to achieve specific goals." >}}
+Each of the How-to Guides contains practical steps for completing a task with CUE.
+{{< /card >}}
+{{< /cards >}}
+
+
+## Attributes
+
+href
+: optional - makes it possible to link to another page or location on the page.
+
+label
+: optional/required - text for the button. If there is no href, there is no need to add a label. When there is a href, it is highly recommended to add a label.
+
+title
+: optional - adds a title to the card.

--- a/hugo/layouts/shortcodes/card.html
+++ b/hugo/layouts/shortcodes/card.html
@@ -1,0 +1,21 @@
+{{ if .Parent }}
+    {{- $href := .Get "href" | default "" -}}
+    {{- $label := .Get "label" | default "" -}}
+    {{- $title := .Get "title" | default "" -}}
+    {{- $content := .Inner -}}
+
+    {{ if not (.Parent.Scratch.Get "cards") }}
+        {{ .Parent.Scratch.Set "cards" slice }}
+    {{ end }}
+
+    {{ with .Inner }}
+        {{ $.Parent.Scratch.Add "cards" (dict
+            "href" $href
+            "label" $label
+            "title" $title
+            "content" $content
+        ) }}
+    {{ end }}
+{{ else }}
+    {{- errorf "[%s] %q: card shortcode is missing its parent" site.Language.Lang .Page.Path -}}
+{{ end}}

--- a/hugo/layouts/shortcodes/cards.html
+++ b/hugo/layouts/shortcodes/cards.html
@@ -1,0 +1,30 @@
+{{ with .Inner }}{{/* don't do anything, just call it because hugo needs it */}}{{ end }}
+
+{{ $cards := .Scratch.Get "cards" | default slice }}
+
+<div class="cards">
+    <ul class="cards__items">
+        {{ range $index, $card := $cards }}
+            <div class="cards__item">
+                <h3 class="cards__title">{{ $card.title }}</h3>
+
+                <div class="cards__content">
+                    {{ $card.content | markdownify }}
+                </div>
+
+                {{ if and $card.href $card.label }}
+                    <div class="link cards__readmore">
+                        <span class="cards__label">{{ $card.label }}</span>
+                        {{ partial "icon.html" (dict "icon" "chevron-right" "class" "link__icon cards__icon") }}
+                    </div>
+                {{ end }}
+
+                {{ if $card.href }}
+                    <a class="cards__link" aria-label="{{ $card.label }}" href="{{ $card.href }}">
+                        <span>{{ $card.label }}</span>
+                    </a>
+                {{ end }}
+            </div>
+        {{ end }}
+    </ul>
+</div>


### PR DESCRIPTION
- Added cards & card shortcode html
- Added cards & card shortcode styling
- Set up example page for card shortcode
- Added link to example page on example overview page
- Improved icon styling in link

For https://linear.app/usmedia/issue/CUE-343