### PR TITLE
Hugo: default search input placeholder

### DIFF
--- a/hugo/i18n/en.toml
+++ b/hugo/i18n/en.toml
@@ -94,6 +94,8 @@ other = "documents found"
 [search_filters_title]
 other = "Filters"
 [search_placeholder]
+other = "Search in cuelang.org"
+[search_placeholder_content_type]
 other = "Search in {{ .contentType }}"
 
 [search_tags_title]

--- a/hugo/layouts/partials/search.html
+++ b/hugo/layouts/partials/search.html
@@ -3,7 +3,11 @@
 {{ $contentTypes := slice }}
 {{ $contentType := .contentType | default "" }}
 {{ $type := .type | default "full" }}
-{{ $placeholder := (T "search_placeholder" .) }}
+{{ $placeholder := (T "search_placeholder" ) }}
+
+{{ if $contentType }}
+    {{ $placeholder = (T "search_placeholder_content_type" .) }}
+{{ end }}
 
 {{ with $context }}
     {{ if $showContentTypes }}


### PR DESCRIPTION
When no contentType was used, the search input showed "Search in <no value". There only is a contentType when using the search shortcode.

- Default placeholder is now "Search in cuelang.org" (/search/?q=)
- When using the search shortcode with a contentType, you see eg. "Search in How-to Guides"  (/examples/shortcodes/search/)

For https://linear.app/usmedia/issue/CUE-344