### PR TITLE
Hugo: moved share in article footer to top

### DIFF
--- a/hugo/assets/scss/components/article.scss
+++ b/hugo/assets/scss/components/article.scss
@@ -99,6 +99,11 @@
     &__share {
         flex: 0 0 46px;
         height: 46px;
+
+        &:only-child {
+            margin-left: auto;
+            margin-top: -3.75rem
+        }
     }
 
     &--blog {

--- a/hugo/layouts/partials/article--footer.html
+++ b/hugo/layouts/partials/article--footer.html
@@ -11,11 +11,11 @@
     </div>
 
     <div class="article__footer-meta">
-        <div class="article__footer-tags">
-            {{- if $tags -}}
+        {{- if $tags -}}
+            <div class="article__footer-tags">
                 {{- partial "tags.html" (dict "tags" $tags) -}}
-            {{- end -}}
-        </div>
+            </div>
+        {{- end -}}
 
         <div class="article__share">
             {{- partial "share.html" . -}}


### PR DESCRIPTION
Moved the share button in article footer to top when there are no tags. Now it is at the same height as the "last modified".

For testing, scroll down to footer in eg. /docs/howto/about-these-guides/

For https://linear.app/usmedia/issue/CUE-342