### PR TITLE
Hugo: same footer on overview as content in docs

### DIFF
--- a/hugo/layouts/docs/list.html
+++ b/hugo/layouts/docs/list.html
@@ -5,7 +5,6 @@
 
             <article class="article article--docs">
                 <div class="article__container">
-
                     <div class="article__content">
                         {{ .Content }}
 
@@ -14,14 +13,13 @@
                         {{ end }}
                     </div>
 
-                    <footer class="article__footer">
-                        {{ partial "last-modified.html" . }}
-                    </footer>
+                    {{- partial "article--footer" . -}}
                 </div>
             </article>
 
             {{ partial "paging/prev-next.html" . }}
         </div>
+    
         <div id="docs-menu" class="docs__aside">
             <div class="docs__backdrop" data-docs-close="docs"></div>
             <div class="docs__nav">


### PR DESCRIPTION
Add the same article footer on the docs overview pages (/docs/howto) as the content pages (/docs/howto/use-the-preprocessor).

For testing: other than "last modified", the overview page now also has a share button and optional tags.

For https://linear.app/usmedia/issue/CUE-341