### PR TITLE
Hugo/playground: add report an issue link to playground

### DIFF
--- a/hugo/layouts/_default/playground.html
+++ b/hugo/layouts/_default/playground.html
@@ -1,3 +1,15 @@
+{{ $versionCommit := print $.Site.Params.github_repo "/commit/" .Site.Data.Repository.Revision }}
+{{ $issueBody := (print
+    "### What page were you looking at?\n\n"
+    .Permalink "\n\n"
+    "### What version of the site were you looking at?\n\n"
+    $versionCommit "\n\n"
+    "### What did you do?\n\n\n\n"
+    "### What did you expect?\n\n\n\n"
+    "### What did you see instead?\n\n") | urlquery
+}}
+{{ $issueUrl := (print "https://github.com/cue-lang/cue/issues/new?labels=Triage,NeedsInvestigation,cuelang.org&title=alpha.cuelang.org:%20&body=" $issueBody) | htmlUnescape | safeHTML }}
+
 <!doctype html>
 <html lang="{{ .Site.Language.Lang }}" dir="{{ .Site.Language.LanguageDirection }}" class="no-js">
     <head>{{ partial "site/head.html" . }}</head>
@@ -8,9 +20,10 @@
             </div>
         </main>
         <script>
-            document.editorEnv = {
+            document.playgroundEnv = {
                 baseUrl: {{ .Site.BaseURL | absURL }},
-                wasmPath: '/playground'
+                wasmPath: '/playground',
+                issueUrl: {{ $issueUrl }},
             }
         </script>
         <link rel="stylesheet" href="{{ "/playground/main.css" | relURL }}">

--- a/playground/src/components/header.tsx
+++ b/playground/src/components/header.tsx
@@ -107,7 +107,7 @@ export class Header extends React.Component<HeaderProps, HeaderState>
                                 { mainNav.map((navItem) => {
                                     return (
                                         <li className="cue-nav__item" key={ navItem.url }>
-                                            <a className="cue-nav__link" href={ navItem.url }>
+                                            <a className="cue-nav__link" href={ navItem.url } target={ navItem.target || '_self' }>
                                                 <span className="cue-nav__text">{ navItem.title }</span>
                                             </a>
                                         </li>

--- a/playground/src/config/nav.ts
+++ b/playground/src/config/nav.ts
@@ -1,4 +1,5 @@
-import { NavItem } from '@models/nav';
+import { NavItem, TARGET_TYPE } from '@models/nav';
+import { environment } from 'environment';
 
 export const mainNav: NavItem[] = [
     { url: '/', title: 'CUE home' },
@@ -7,4 +8,5 @@ export const mainNav: NavItem[] = [
     { url: 'https://github.com/cue-lang/cue/releases', title: 'Download CUE' },
     { url: '/community', title: 'Community' },
     { url: 'https://github.com/cue-lang/cue', title: 'Github' },
+    { url: environment.issueUrl, title: 'Report an issue', target: TARGET_TYPE.BLANK },
 ];

--- a/playground/src/environment.ts
+++ b/playground/src/environment.ts
@@ -1,6 +1,6 @@
 declare global {
     interface DocumentEnv extends Document {
-        editorEnv?: {
+        playgroundEnv?: {
             [key: string]: boolean | string | number;
         };
     }
@@ -9,12 +9,14 @@ declare global {
 export class Environment {
     baseUrl: string;
     wasmPath: string;
+    issueUrl: string;
 
     constructor() {
-        const envVars = (document as DocumentEnv).editorEnv ? (document as DocumentEnv).editorEnv : {};
+        const envVars = (document as DocumentEnv).playgroundEnv ? (document as DocumentEnv).playgroundEnv : {};
 
         this.baseUrl = envVars ? String(envVars['baseUrl']) : '';
         this.wasmPath = envVars ? String(envVars['wasmPath']) : '';
+        this.issueUrl = envVars ? String(envVars['issueUrl']) : '';
     }
 }
 

--- a/playground/src/index.html
+++ b/playground/src/index.html
@@ -9,9 +9,10 @@
         <link rel="stylesheet" href="main.css">
         <link rel="shortcut icon" href="/favicons/favicon.ico">
         <script>
-            document.editorEnv = {
+            document.playgroundEnv = {
                 baseUrl: 'http://localhost:3000',
-                wasmPath: ''
+                wasmPath: '',
+                issueUrl: '',
             }
         </script>
     </head>

--- a/playground/src/models/nav.ts
+++ b/playground/src/models/nav.ts
@@ -1,4 +1,12 @@
+export enum TARGET_TYPE {
+    BLANK = '_blank',
+    SELF = '_self',
+    PARENT = '_parent',
+    TOP = '_top',
+}
+
 export interface NavItem {
     url: string;
     title: string;
+    target?: TARGET_TYPE;
 }


### PR DESCRIPTION
- Passing issueUrl to playground
- Add issueUrl to playground menu
- name change editorEnv to playgroundEnv
- add option to add target to menu link

Testing:
1. go to playground
2. open menu (3 dots)
3. click on "report an issue" 
Github should open in a new tab with prefilled text, including the page url and commit version.

For https://linear.app/usmedia/issue/CUE-303