### PR TITLE
Playground: do not index or crawl playground links with 'id'

### DIFF
--- a/hugo/layouts/robots.txt
+++ b/hugo/layouts/robots.txt
@@ -1,4 +1,5 @@
 User-agent: *
 Allow: /
+Disallow: /play/*?*id=
 
 Sitemap: {{ absURL "sitemap.xml" }}


### PR DESCRIPTION
- Added Disallow: /play/*?id= to robots.txt

For https://linear.app/usmedia/issue/CUE-289