### PR TITLE
Content: added extra front-matter options to example page

### DIFF
--- a/content/blog/example/en.md
+++ b/content/blog/example/en.md
@@ -2,7 +2,7 @@
 title: Example blog page and also a longer title
 date: "2023-04-06"
 draft: false
-noindex: true
+no_index: true
 image: "cow.jpg"
 authors:
     - myitcv

--- a/content/blog/example2/en.md
+++ b/content/blog/example2/en.md
@@ -2,7 +2,7 @@
 title: Example blog page 2 with a longer title
 date: "2023-01-01"
 draft: false
-noindex: true
+no_index: true
 image: "allium.jpg"
 ---
 

--- a/content/blog/example3/en.md
+++ b/content/blog/example3/en.md
@@ -2,7 +2,7 @@
 title: Example blog page 3
 date: "2023-03-10"
 draft: false
-noindex: true
+no_index: true
 image: "moon.jpg"
 ---
 

--- a/content/blog/example4/en.md
+++ b/content/blog/example4/en.md
@@ -2,7 +2,7 @@
 title: Example blog page 4
 date: "2023-03-10"
 draft: false
-noindex: true
+no_index: true
 image: "birds.jpg"
 ---
 

--- a/content/examples/basic/front-matter/en.md
+++ b/content/examples/basic/front-matter/en.md
@@ -88,5 +88,27 @@ tags:
 authors
 : adding the author(s) to the frontmatter, makes the content header show an image + name of the assigned author. It also shows a popup on click, with again an image + (display) name, and when available a link to their Github, and a link to the search page so users can search for other articles of this author.
 
-noindex
-: adding noindex: true to the front-matter add the meta tag `<meta name="robots" content="noindex, nofollow">` to the head of the page. Also the pages will be excluded from the sitemap.xml.
+no_index
+: adding `no_index: true` to the front-matter adds the meta tag `<meta name="robots" content="noindex, nofollow">` to the head of the page. Also the pages will be excluded from the sitemap.xml.
+
+## Docs specific front-matter
+
+disabled
+: shows page without the content, but with a TODO block
+
+hide_summary
+: adding `hide_summary: true` will remove the page from the list on a docs overview page (eg. /docs/howto). It will still show in the left hand nav, and the prev/next buttons.
+
+index_hide
+: adding `index_hide: true` will hide the list of children on a docs overview page (eg. /docs/howto)
+
+toc_hide
+: `toc_hide: true` will hide the table of contents in the left hand nav
+
+toc_root
+: `toc_root: true` will set the page as the parent, hiding all other levels of the left hand nav. The left hand nav will only show the (grand)children of the page.
+
+## Blog specific front-matter
+
+image
+: adds a header image to the blog page. Also shows in the blog teaser.

--- a/hugo/content/en/blog/example/index.md
+++ b/hugo/content/en/blog/example/index.md
@@ -2,7 +2,7 @@
 title: Example blog page and also a longer title
 date: "2023-04-06"
 draft: false
-noindex: true
+no_index: true
 image: "cow.jpg"
 authors:
     - myitcv

--- a/hugo/content/en/blog/example2/index.md
+++ b/hugo/content/en/blog/example2/index.md
@@ -2,7 +2,7 @@
 title: Example blog page 2 with a longer title
 date: "2023-01-01"
 draft: false
-noindex: true
+no_index: true
 image: "allium.jpg"
 ---
 

--- a/hugo/content/en/blog/example3/index.md
+++ b/hugo/content/en/blog/example3/index.md
@@ -2,7 +2,7 @@
 title: Example blog page 3
 date: "2023-03-10"
 draft: false
-noindex: true
+no_index: true
 image: "moon.jpg"
 ---
 

--- a/hugo/content/en/blog/example4/index.md
+++ b/hugo/content/en/blog/example4/index.md
@@ -2,7 +2,7 @@
 title: Example blog page 4
 date: "2023-03-10"
 draft: false
-noindex: true
+no_index: true
 image: "birds.jpg"
 ---
 

--- a/hugo/content/en/examples/basic/front-matter/index.md
+++ b/hugo/content/en/examples/basic/front-matter/index.md
@@ -88,5 +88,27 @@ tags:
 authors
 : adding the author(s) to the frontmatter, makes the content header show an image + name of the assigned author. It also shows a popup on click, with again an image + (display) name, and when available a link to their Github, and a link to the search page so users can search for other articles of this author.
 
-noindex
-: adding noindex: true to the front-matter add the meta tag `<meta name="robots" content="noindex, nofollow">` to the head of the page. Also the pages will be excluded from the sitemap.xml.
+no_index
+: adding `no_index: true` to the front-matter adds the meta tag `<meta name="robots" content="noindex, nofollow">` to the head of the page. Also the pages will be excluded from the sitemap.xml.
+
+## Docs specific front-matter
+
+disabled
+: shows page without the content, but with a TODO block
+
+hide_summary
+: adding `hide_summary: true` will remove the page from the list on a docs overview page (eg. /docs/howto). It will still show in the left hand nav, and the prev/next buttons.
+
+index_hide
+: adding `index_hide: true` will hide the list of children on a docs overview page (eg. /docs/howto)
+
+toc_hide
+: `toc_hide: true` will hide the table of contents in the left hand nav
+
+toc_root
+: `toc_root: true` will set the page as the parent, hiding all other levels of the left hand nav. The left hand nav will only show the (grand)children of the page.
+
+## Blog specific front-matter
+
+image
+: adds a header image to the blog page. Also shows in the blog teaser.

--- a/hugo/layouts/_default/sitemap.xml
+++ b/hugo/layouts/_default/sitemap.xml
@@ -1,6 +1,6 @@
 {{ printf "<?xml version=\"1.0\" encoding=\"utf-8\" standalone=\"yes\"?>" | safeHTML }}
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9" xmlns:xhtml="http://www.w3.org/1999/xhtml">
-    {{ range where (where .Data.Pages "Type" "!=" "examples") "Params.noindex" "ne" true }}
+    {{ range where (where .Data.Pages "Type" "!=" "examples") "Params.no_index" "ne" true }}
         {{- if .Permalink -}}
             <url>
                 <loc>{{ .Permalink }}</loc>

--- a/hugo/layouts/partials/site/head.html
+++ b/hugo/layouts/partials/site/head.html
@@ -5,7 +5,7 @@
 {{ else }}{{ with .Site.Params.description -}}{{- . | $.RenderString | plainify -}}
 {{ end }}{{ end }}{{ end -}}">
 {{ hugo.Generator }}
-{{ if and (eq (getenv "HUGO_ENV") "production") (ne .Params.noindex true) (ne .Type "examples") }}
+{{ if and (eq (getenv "HUGO_ENV") "production") (ne .Params.no_index true) (ne .Type "examples") }}
 <meta name="robots" content="index, follow">
 {{ else }}
 <meta name="robots" content="noindex, nofollow">


### PR DESCRIPTION
- Added possible front-matter options to example page (/examples/basic/front-matter/)
- Fixed front-matter typo in head.html

For https://linear.app/usmedia/issue/CUE-340