### PR TITLE
Hugo: remove deprecated social.twitter from config

### DIFF
--- a/hugo/config/_default/config.toml
+++ b/hugo/config/_default/config.toml
@@ -51,9 +51,6 @@ disableAliases = false
     [mediaTypes."text/netlify"]
         delimiter = ""
 
-[social]
-    twitter = "cue_lang"
-
 [build]
     noJSConfigInAssets = true
 


### PR DESCRIPTION
Removed the social key in the site configuration. Wanted to add it to the params.toml, but noticed the DO NOT EDIT note.

It looks like social.twitter is not used anywhere. If it is, it needs to be added to the params.toml and can be called with Site.Params.social.twitter

For https://linear.app/usmedia/issue/CUE-345