### PR TITLE
Hugo: add 'clear all items' button to filter dropdowns

### DIFF
--- a/hugo/assets/scss/components/filter.scss
+++ b/hugo/assets/scss/components/filter.scss
@@ -1,4 +1,5 @@
 @import '../config/colors';
+@import '../config/typography';
 @import '../mixins/button';
 @import '../mixins/sr-only';
 @import '../mixins/svg';
@@ -143,6 +144,12 @@
                 vertical-align: -3px;
                 width: 12px;
             }
+        }
+
+        &--clear {
+            color: $c-red;
+            justify-content: center;
+            padding: 0.5rem 1.875rem;
         }
     }
 

--- a/hugo/assets/ts/widgets/search-filter.ts
+++ b/hugo/assets/ts/widgets/search-filter.ts
@@ -84,20 +84,35 @@ export class SearchFilter extends BaseWidget {
             return `<li class="filter__item">
                 <button class="filter__link${ isSelected ? ' is-selected' : '' }"
                 type="button" data-value="${ item.name }">
-                    ${ item.color ? `<span class="filter__color filter__color--${ item.color }"></span>` : ''}
+                    ${ item.color ? `<span class="filter__color filter__color--${ item.color }"></span>` : '' }
                     ${ item.name }
                 </button>
             </li>`;
         });
 
+        if (this.selectedItems.length > 0) {
+            html.push(
+                `<li class="filter__item">
+                    <button class="filter__link filter__link--clear" type="button" data-clear=true>
+                        <span>Clear all items</span>
+                    </button>
+                </li>`
+            );
+        }
+
         this.listContainer.innerHTML = html.join('');
 
         const filterLinks = this.element.querySelectorAll<HTMLButtonElement>('button.filter__link');
         filterLinks.forEach((link) => {
-           link.addEventListener('click', (e) => {
-               e.preventDefault();
-               this.onClickFilter(link.dataset.value);
-           });
+            link.addEventListener('click', (e) => {
+                e.preventDefault();
+
+                if (link.dataset.value) {
+                    this.onClickFilter(link.dataset.value);
+                } else if (link.dataset.clear) {
+                    this.onClearFilter();
+                }
+            });
         });
     }
 
@@ -117,6 +132,11 @@ export class SearchFilter extends BaseWidget {
             this.parsedQuery.facets[this.filterName].push(value);
             this.updateUrl();
         }
+    }
+
+    private onClearFilter() {
+        this.parsedQuery.facets[this.filterName] = [];
+        this.updateUrl();
     }
 
     private updateUrl() {


### PR DESCRIPTION
- Added 'clear all items' functionality
- Added 'clear all items' styling

Testing:
1. Go to the search page (/search/?q=)
2. Select some of the filters in the dropdown
3. See that the "clear all items" option only shows when there is one or more item(s) selected
4. Click on the "clear all items" button to deselect all the selected options in that dropdown.

For https://linear.app/usmedia/issue/CUE-301