### PR TITLE
Hugo: breaking shortcodes in shortcodes

### DIFF
--- a/hugo/layouts/partials/icon.html
+++ b/hugo/layouts/partials/icon.html
@@ -1,6 +1,7 @@
 {{ $icon     := .icon | default "help" }}
 {{ $sprite   := .sprite | default "ui"  }}
 {{ $cssClass := .class | default "" }}
+
 <svg class="icon{{ if $cssClass }} {{ $cssClass }}{{ end }}" aria-hidden="true">
     <use xmlns:xlink="http://www.w3.org/1999/xlink"
          xlink:href="{{ (printf "/img/%s.svg" $sprite) | absURL }}#icon--{{ $icon }}"></use>

--- a/hugo/layouts/partials/tabs.html
+++ b/hugo/layouts/partials/tabs.html
@@ -4,15 +4,15 @@
 
 <div class="tabs{{ if $modifier }} tabs--{{ $modifier }}{{ end }}" data-tabs data-group="{{ $groupId }}">
     <div class="tabs__nav tabs-nav{{ if $modifier }} tabs-nav--{{ $modifier }}{{ end }}" data-tabs-nav>
-        {{ if gt ($tabs | len ) 1 }}
+        {{- if gt ($tabs | len ) 1 -}}
             <button class="tabs-nav__pagination tabs-nav__pagination--prev is-hidden">
                 <span class="tabs-nav__icon">
-                    {{ partial "icon.html" (dict "class" "" "icon" "chevron-left") }}
+                    {{- partial "icon.html" (dict "class" "" "icon" "chevron-left") -}}
                 </span>
             </button>
 
             <ul class="tabs-nav__tabs">
-                {{ range $idx, $tab := $tabs }}
+                {{- range $idx, $tab := $tabs -}}
                     <li class="tabs-nav__item">
                         <button
                             data-tab-item="{{ .name | urlize }}"
@@ -20,35 +20,36 @@
                             class="tabs-nav__tab{{ if ne .type "default" }} tabs-nav__tab--{{ .type}}{{ end}}{{ cond (eq $idx 0) " is-active" ""}}"
                         >{{ .name }}</button>
                     </li>
-                {{ end }}
+                {{- end -}}
             </ul>
 
             <button class="tabs-nav__pagination tabs-nav__pagination--next is-hidden">
                 <span class="tabs-nav__icon">
-                    {{ partial "icon.html" (dict "class" "" "icon" "chevron-right") }}
+                    {{- partial "icon.html" (dict "class" "" "icon" "chevron-right") -}}
                 </span>
             </button>
-        {{ else }}
-            {{ range $idx, $tab := $tabs }}
+        {{- else -}}
+            {{- range $idx, $tab := $tabs -}}
                 <div class="tabs-nav__item">
                     <div
                         data-tab-item="{{ .name | urlize }}"
                         data-tab-group="{{ $groupId }}"
                         class="tabs-nav__tab{{ if ne .type "default" }} tabs-nav__tab--{{ .type}}{{ end}}"
-                    >{{ .name }}</div>
+                    >{{- .name -}}</div>
                 </div>
-            {{ end }}
-        {{ end }}
+            {{- end -}}
+        {{- end -}}
     </div>
 
-    <div class="tabs__content">
-        {{ range $idx, $tab := $tabs }}
-            <div data-tab-item="{{ .name | urlize }}"
-                 data-tab-group="{{ $groupId }}"
-                 class="tabs__item {{ cond (eq $idx 0) "is-active" ""}}"
-            >{{ .content | markdownify }}
-            </div>
-        {{ end }}
-    </div>
+{{/*  Do not 'fix' this indent, it breaks when the tabs are used in other shortcodes  */}}
+<div class="tabs__content">
+    {{- range $idx, $tab := $tabs -}}
+        <div data-tab-item="{{ .name | urlize }}"
+            data-tab-group="{{ $groupId }}"
+            class="tabs__item {{ cond (eq $idx 0) "is-active" ""}}"
+        >{{- .content | markdownify -}}
+        </div>
+    {{- end -}}
+</div>
 </div>
 

--- a/hugo/layouts/shortcodes/caution.html
+++ b/hugo/layouts/shortcodes/caution.html
@@ -1,11 +1,11 @@
 <div class="note note--caution" role="alert">
-    {{ partial "icon.html" (dict "icon" "exclamation" "class" "note__icon") }}
+    {{- partial "icon.html" (dict "icon" "exclamation" "class" "note__icon") -}}
 
     <div class="note__content">
-        {{ if eq .Page.File.Ext "md" -}}
-            {{ .Inner | markdownify }}
-        {{ else -}}
-            {{ .Inner | htmlUnescape | safeHTML }}
-        {{- end }}
+        {{- if eq .Page.File.Ext "md" -}}
+            {{- .Inner | markdownify -}}
+        {{- else -}}
+            {{- .Inner | htmlUnescape | safeHTML -}}
+        {{- end -}}
     </div>
 </div>

--- a/hugo/layouts/shortcodes/code-tabs.html
+++ b/hugo/layouts/shortcodes/code-tabs.html
@@ -11,85 +11,84 @@
 {{- $tabsLeft := .Scratch.Get "tabs-left" -}}
 {{- $tabsRight := .Scratch.Get "tabs-right" -}}
 
-
 <div class="code-tabs"{{ if $height }} style="height: {{ $height }}px"{{ end }}>
-    {{ if $tabsTop }}
+    {{- if $tabsTop -}}
         <div class="code-tabs__item code-tabs__item--top">
-            {{ partial "tabs.html" (dict
-            "groupId" $groupId
-            "tabs" $tabsTop
-            "modifier" "code"
-            ) }}
+            {{- partial "tabs.html" (dict
+                "groupId" $groupId
+                "tabs" $tabsTop
+                "modifier" "code"
+            ) -}}
         </div>
-    {{ end }}
+    {{- end -}}
 
-    {{ if $tabsLeft }}
+    {{- if $tabsLeft -}}
         <div class="code-tabs__item code-tabs__item--left">
-            {{ partial "tabs.html" (dict
-            "groupId" $groupId
-            "tabs" $tabsLeft
-            "modifier" "code"
-            ) }}
+            {{- partial "tabs.html" (dict
+                "groupId" $groupId
+                "tabs" $tabsLeft
+                "modifier" "code"
+            ) -}}
         </div>
-    {{ end }}
+    {{- end -}}
 
-    {{ if $tabsTopLeft }}
+    {{- if $tabsTopLeft -}}
         <div class="code-tabs__item code-tabs__item--top-left">
-            {{ partial "tabs.html" (dict
+            {{- partial "tabs.html" (dict
                 "groupId" $groupId
                 "tabs" $tabsTopLeft
                 "modifier" "code"
-            ) }}
+            ) -}}
         </div>
-    {{ end }}
+    {{- end -}}
 
-    {{ if $tabsBottomLeft }}
+    {{- if $tabsBottomLeft -}}
         <div class="code-tabs__item code-tabs__item--bottom-left">
-            {{ partial "tabs.html" (dict
+            {{- partial "tabs.html" (dict
                 "groupId" $groupId
                 "tabs" $tabsBottomLeft
                 "modifier" "code"
-            ) }}
+            ) -}}
         </div>
-    {{ end }}
+    {{- end -}}
 
     {{ if $tabsRight }}
         <div class="code-tabs__item code-tabs__item--right">
-            {{ partial "tabs.html" (dict
-            "groupId" $groupId
-            "tabs" $tabsRight
-            "modifier" "code"
-            ) }}
+            {{- partial "tabs.html" (dict
+                "groupId" $groupId
+                "tabs" $tabsRight
+                "modifier" "code"
+            ) -}}
         </div>
     {{ end }}
 
     {{ if $tabsTopRight }}
         <div class="code-tabs__item code-tabs__item--top-right">
-            {{ partial "tabs.html" (dict
+            {{- partial "tabs.html" (dict
                 "groupId" $groupId
                 "tabs" $tabsTopRight
                 "modifier" "code"
-            ) }}
+            ) -}}
         </div>
     {{ end }}
 
     {{ if $tabsBottomRight }}
         <div class="code-tabs__item code-tabs__item--bottom-right">
-            {{ partial "tabs.html" (dict
+            {{- partial "tabs.html" (dict
                 "groupId" $groupId
                 "tabs" $tabsBottomRight
                 "modifier" "code"
-            ) }}
+            ) -}}
         </div>
     {{ end }}
 
     {{ if $tabsBottom }}
         <div class="code-tabs__item code-tabs__item--bottom">
-            {{ partial "tabs.html" (dict
+            {{- partial "tabs.html" (dict
                 "groupId" $groupId
                 "tabs" $tabsBottom
                 "modifier" "code"
-            ) }}
+            ) -}}
         </div>
     {{ end }}
 </div>

--- a/hugo/layouts/shortcodes/columns.html
+++ b/hugo/layouts/shortcodes/columns.html
@@ -1,9 +1,9 @@
 <div id="side-{{ .Ordinal }}" class="columns">
     <div class="columns__col">
-        {{ if eq .Page.File.Ext "md" }}
-            {{ .Inner | markdownify }}
-        {{ else }}
-            {{ .Inner | htmlUnescape | safeHTML }}
-        {{ end }}
+        {{- if eq .Page.File.Ext "md" -}}
+            {{- .Inner | markdownify -}}
+        {{- else -}}
+            {{- .Inner | htmlUnescape | safeHTML -}}
+        {{- end -}}
     </div>
 </div>

--- a/hugo/layouts/shortcodes/info.html
+++ b/hugo/layouts/shortcodes/info.html
@@ -1,11 +1,11 @@
 <div class="note note--info" role="alert">
-    {{ partial "icon.html" (dict "icon" "exclamation" "class" "note__icon") }}
+    {{- partial "icon.html" (dict "icon" "exclamation" "class" "note__icon") -}}
 
     <div class="note__content">
-        {{ if eq .Page.File.Ext "md" -}}
-            {{ .Inner | markdownify }}
-        {{ else -}}
-            {{ .Inner | htmlUnescape | safeHTML }}
-        {{- end }}
+        {{- if eq .Page.File.Ext "md" -}}
+            {{- .Inner | markdownify -}}
+        {{- else -}}
+            {{- .Inner | htmlUnescape | safeHTML -}}
+        {{- end -}}
     </div>
 </div>

--- a/hugo/layouts/shortcodes/step.html
+++ b/hugo/layouts/shortcodes/step.html
@@ -3,17 +3,17 @@
 {{ $id := cond (ne $group false) (print $group "-step-" $stepNumber) (print "step-" $stepNumber) }}
 
 <div class="step" id="{{ $id }}" data-step-group="{{ $group }}">
-    {{ if $stepNumber }}
+    {{- if $stepNumber -}}
         <a class="button button--icon button--yellow step__number" href="#{{ $id }}" data-step-number="{{ $stepNumber }}">
             {{- $stepNumber -}}
         </a>
-    {{ end }}
+    {{- end -}}
 
     <div class="step__content">
-        {{ if eq .Page.File.Ext "md" }}
-            {{ .Inner | markdownify }}
-        {{ else }}
-            {{ .Inner | htmlUnescape | safeHTML }}
-        {{ end }}
+        {{- if eq .Page.File.Ext "md" -}}
+            {{- .Inner | markdownify -}}
+        {{- else -}}
+            {{- .Inner | htmlUnescape | safeHTML -}}
+        {{- end -}}
     </div>
 </div>

--- a/hugo/layouts/shortcodes/warning.html
+++ b/hugo/layouts/shortcodes/warning.html
@@ -1,11 +1,11 @@
 <div class="note note--warn" role="alert">
-    {{ partial "icon.html" (dict "icon" "exclamation" "class" "note__icon") }}
+    {{- partial "icon.html" (dict "icon" "exclamation" "class" "note__icon") -}}
 
     <div class="note__content">
-        {{ if eq .Page.File.Ext "md" -}}
-            {{ .Inner | markdownify }}
-        {{ else -}}
-            {{ .Inner | htmlUnescape | safeHTML }}
-        {{- end }}
+        {{- if eq .Page.File.Ext "md" -}}
+            {{- .Inner | markdownify -}}
+        {{- else -}}
+            {{- .Inner | htmlUnescape | safeHTML -}}
+        {{- end -}}
     </div>
 </div>


### PR DESCRIPTION
Add spaceless ('-') to statements and variables so the "markdownify" doesn't break the html code.
In the tabs.html the indent had to be undone for it to work.

For https://github.com/cue-lang/cue/issues/3005 and https://github.com/cue-lang/cue/issues/3002