### PR TITLE
hugo: remove indenting tabs so they do not break

### DIFF
--- a/hugo/layouts/partials/tabs.html
+++ b/hugo/layouts/partials/tabs.html
@@ -2,46 +2,47 @@
 {{ $tabs := .tabs | default slice }}
 {{ $modifier := .modifier | default "" }}
 
+{{/*  Do not 'fix' these indents, it breaks when the tabs are used in other shortcodes  */}}
 <div class="tabs{{ if $modifier }} tabs--{{ $modifier }}{{ end }}" data-tabs data-group="{{ $groupId }}">
-    <div class="tabs__nav tabs-nav{{ if $modifier }} tabs-nav--{{ $modifier }}{{ end }}" data-tabs-nav>
-        {{- if gt ($tabs | len ) 1 -}}
-            <button class="tabs-nav__pagination tabs-nav__pagination--prev is-hidden">
-                <span class="tabs-nav__icon">
-                    {{- partial "icon.html" (dict "class" "" "icon" "chevron-left") -}}
-                </span>
-            </button>
+<div class="tabs__nav tabs-nav{{ if $modifier }} tabs-nav--{{ $modifier }}{{ end }}" data-tabs-nav>
 
-            <ul class="tabs-nav__tabs">
-                {{- range $idx, $tab := $tabs -}}
-                    <li class="tabs-nav__item">
-                        <button
-                            data-tab-item="{{ .name | urlize }}"
-                            data-tab-group="{{ $groupId }}"
-                            class="tabs-nav__tab{{ if ne .type "default" }} tabs-nav__tab--{{ .type}}{{ end}}{{ cond (eq $idx 0) " is-active" ""}}"
-                        >{{ .name }}</button>
-                    </li>
-                {{- end -}}
-            </ul>
+{{- if gt ($tabs | len ) 1 -}}
+<button class="tabs-nav__pagination tabs-nav__pagination--prev is-hidden">
+    <span class="tabs-nav__icon">
+        {{- partial "icon.html" (dict "class" "" "icon" "chevron-left") -}}
+    </span>
+</button>
 
-            <button class="tabs-nav__pagination tabs-nav__pagination--next is-hidden">
-                <span class="tabs-nav__icon">
-                    {{- partial "icon.html" (dict "class" "" "icon" "chevron-right") -}}
-                </span>
-            </button>
-        {{- else -}}
-            {{- range $idx, $tab := $tabs -}}
-                <div class="tabs-nav__item">
-                    <div
-                        data-tab-item="{{ .name | urlize }}"
-                        data-tab-group="{{ $groupId }}"
-                        class="tabs-nav__tab{{ if ne .type "default" }} tabs-nav__tab--{{ .type}}{{ end}}"
-                    >{{- .name -}}</div>
-                </div>
-            {{- end -}}
-        {{- end -}}
-    </div>
+<ul class="tabs-nav__tabs">
+    {{- range $idx, $tab := $tabs -}}
+        <li class="tabs-nav__item">
+            <button
+                data-tab-item="{{ .name | urlize }}"
+                data-tab-group="{{ $groupId }}"
+                class="tabs-nav__tab{{ if ne .type "default" }} tabs-nav__tab--{{ .type}}{{ end}}{{ cond (eq $idx 0) " is-active" ""}}"
+            >{{ .name }}</button>
+        </li>
+    {{- end -}}
+</ul>
 
-{{/*  Do not 'fix' this indent, it breaks when the tabs are used in other shortcodes  */}}
+<button class="tabs-nav__pagination tabs-nav__pagination--next is-hidden">
+    <span class="tabs-nav__icon">
+        {{- partial "icon.html" (dict "class" "" "icon" "chevron-right") -}}
+    </span>
+</button>
+{{- else -}}
+    {{- range $idx, $tab := $tabs -}}
+        <div class="tabs-nav__item">
+            <div
+                data-tab-item="{{ .name | urlize }}"
+                data-tab-group="{{ $groupId }}"
+                class="tabs-nav__tab{{ if ne .type "default" }} tabs-nav__tab--{{ .type}}{{ end}}"
+            >{{ .name }}</div>
+        </div>
+    {{- end -}}
+{{- end -}}
+</div>
+
 <div class="tabs__content">
     {{- range $idx, $tab := $tabs -}}
         <div data-tab-item="{{ .name | urlize }}"

--- a/hugo/layouts/shortcodes/code-tab.html
+++ b/hugo/layouts/shortcodes/code-tab.html
@@ -1,4 +1,4 @@
-{{ if .Parent }}
+{{- if .Parent -}}
     {{ $name := trim (.Get "name") " " }}
     {{ $area := .Get "area" | default "top-left" }}
     {{ $language := .Get "language" | default "" }}
@@ -9,11 +9,11 @@
     {{ $arrayName := printf "tabs-%s" $area }}
     {{ $content := printf "```%s {type=\"%s\", linenos=\"%s\", codeToCopy=\"%s\" modifier=\"code-block--tab\" }%s```" $language $type $lineos $codeToCopy .Inner }}
 
-    {{ if not (.Parent.Scratch.Get $arrayName) }}
+    {{- if not (.Parent.Scratch.Get $arrayName) -}}
         {{ .Parent.Scratch.Set $arrayName slice }}
-    {{ end }}
+    {{- end -}}
 
-    {{ with .Inner }}
+    {{- with .Inner -}}
         {{ $.Parent.Scratch.Add $arrayName (dict
             "name" $name
             "area" $area
@@ -22,7 +22,7 @@
             "groupId" $groupId
             "content" $content
         ) }}
-    {{ end }}
-{{ else }}
+    {{- end -}}
+{{- else -}}
     {{- errorf "[%s] %q: code-tab shortcode is missing its parent" site.Language.Lang .Page.Path -}}
-{{ end}}
+{{- end -}}

--- a/hugo/layouts/shortcodes/code-tabs.html
+++ b/hugo/layouts/shortcodes/code-tabs.html
@@ -52,7 +52,7 @@
         </div>
     {{- end -}}
 
-    {{ if $tabsRight }}
+    {{- if $tabsRight -}}
         <div class="code-tabs__item code-tabs__item--right">
             {{- partial "tabs.html" (dict
                 "groupId" $groupId
@@ -60,9 +60,9 @@
                 "modifier" "code"
             ) -}}
         </div>
-    {{ end }}
+    {{- end -}}
 
-    {{ if $tabsTopRight }}
+    {{- if $tabsTopRight -}}
         <div class="code-tabs__item code-tabs__item--top-right">
             {{- partial "tabs.html" (dict
                 "groupId" $groupId
@@ -70,9 +70,9 @@
                 "modifier" "code"
             ) -}}
         </div>
-    {{ end }}
+    {{- end -}}
 
-    {{ if $tabsBottomRight }}
+    {{- if $tabsBottomRight -}}
         <div class="code-tabs__item code-tabs__item--bottom-right">
             {{- partial "tabs.html" (dict
                 "groupId" $groupId
@@ -80,9 +80,9 @@
                 "modifier" "code"
             ) -}}
         </div>
-    {{ end }}
+    {{- end -}}
 
-    {{ if $tabsBottom }}
+    {{- if $tabsBottom -}}
         <div class="code-tabs__item code-tabs__item--bottom">
             {{- partial "tabs.html" (dict
                 "groupId" $groupId
@@ -90,5 +90,5 @@
                 "modifier" "code"
             ) -}}
         </div>
-    {{ end }}
+    {{- end -}}
 </div>

--- a/hugo/layouts/shortcodes/tab.html
+++ b/hugo/layouts/shortcodes/tab.html
@@ -1,11 +1,11 @@
-{{ if .Parent }}
+{{- if .Parent -}}
     {{ $name := trim (.Get "name") " " }}
-    {{ if not (.Parent.Scratch.Get "tabs") }}
+    {{- if not (.Parent.Scratch.Get "tabs") -}}
         {{ .Parent.Scratch.Set "tabs" slice }}
-    {{ end }}
-    {{ with .Inner }}
+    {{- end -}}
+    {{- with .Inner -}}
         {{ $.Parent.Scratch.Add "tabs" (dict "name" $name "content" . ) }}
-    {{ end }}
-{{ else }}
+    {{- end -}}
+{{- else -}}
     {{- errorf "[%s] %q: tab shortcode missing its parent" site.Language.Lang .Page.Path -}}
-{{ end}}
+{{- end -}}

--- a/hugo/layouts/shortcodes/tabs.html
+++ b/hugo/layouts/shortcodes/tabs.html
@@ -1,4 +1,4 @@
-{{ with .Inner }}{{/* don't do anything, just call it because hugo needs it */}}{{ end }}
+{{- with .Inner -}}{{/* don't do anything, just call it because hugo needs it */}}{{ end }}
 {{- $groupId := .Get "groupId" | default "default" -}}
 {{- $tabs := .Scratch.Get "tabs" -}}
 


### PR DESCRIPTION
- removed breaking indenting from tabs
- added more spaceless characters

For testing, add the example code from the issue
below to a test page. Check if you see 2 tabs in
the code block.

For https://github.com/cue-lang/cue/issues/3192