### PR TITLE
hugo: Fix search not working on mobile

### DIFF
--- a/hugo/assets/scss/components/searchbar.scss
+++ b/hugo/assets/scss/components/searchbar.scss
@@ -17,7 +17,7 @@
         border: none;
         border-radius: 50px;
         height: $h-button--small + 16px;
-        padding: 0 1.125rem 0 2.5rem;
+        padding: 0 1.125rem 0 2.75rem;
         position: relative;
 
         &:focus-within {


### PR DESCRIPTION
- Move the max width of the detached mode query to a variable so it can be
reused
- Move the on doc click logic to its own function
- Save if autocomplete is open in a variable so we can access it on doc click
- On click of the document only close & reset the algolia-autocomplete when
is not open AND click is outside element AND outside overlay (in detached mode
 overlay is outside the element)
- Fix issue with right side of search-icon in bar not showing on mobile
- Fix type issue with autocomplete: type was unknown so I've added the right
types

Fixes: https://github.com/cue-lang/cue/issues/2848

To test:
On mobile click on the menu (hamburger) and click in the search box. Type in a
 search query and either hit the enter key or click the search icon next to
 the input field.
