### PR TITLE
playground: selected text isn't highlighted

### DIFF
--- a/playground/src/config/editor-theme.ts
+++ b/playground/src/config/editor-theme.ts
@@ -1,0 +1,17 @@
+import { vscodeLightInit } from '@uiw/codemirror-theme-vscode';
+
+export const vscodeLight = vscodeLightInit({
+    settings: {
+        lineHighlight: '#f0f0f0b3',
+        selectionMatch: '#add6ff',
+    },
+});
+
+export const vscodeLightTerminal = vscodeLightInit({
+    settings: {
+        background: '#eef0f5',
+        gutterBackground: '#eef0f5',
+        lineHighlight: '#f0f0f0b3',
+        selectionMatch: '#add6ff',
+    },
+});

--- a/playground/src/containers/app.tsx
+++ b/playground/src/containers/app.tsx
@@ -13,8 +13,7 @@
 // limitations under the License.
 
 import { LanguageName, loadLanguage } from '@uiw/codemirror-extensions-langs';
-import CodeMirror, { EditorView, Extension } from '@uiw/react-codemirror';
-import { vscodeLight } from '@uiw/codemirror-theme-vscode';
+import CodeMirror, { basicSetup, EditorView, Extension } from '@uiw/react-codemirror';
 import { debounce } from 'lodash';
 import * as React from 'react';
 
@@ -22,6 +21,7 @@ import { Header } from '@components/header';
 import { Spinner } from '@components/spinner';
 import { Tab } from '@components/tab';
 import { Tabs } from '@components/tabs';
+import { vscodeLight, vscodeLightTerminal } from '@config/editor-theme';
 import { examples } from '@config/examples';
 import { availableWorkspaces, defaultWorkspace } from '@config/workspaces';
 import { getSharedCode, share, workspaceToShareContent } from '@helpers/share';
@@ -270,10 +270,11 @@ export class App extends React.Component<AppProps, AppState>
                                                         className="cue-editor"
                                                         theme={ vscodeLight }
                                                         value={ tab.code ?? '' }
+                                                        basicSetup={ false }
                                                         extensions={ this.getExtensions(tab.selected.value) }
                                                         onCreateEditor={ async (view) => {
                                                             this.inputEditors[id] = view;
-                                                            // this.updateOutput();
+                                                            this.updateOutput();
                                                         } }
                                                         onChange={ this.onEditorInputChange.bind(this) }
                                                     />
@@ -297,8 +298,9 @@ export class App extends React.Component<AppProps, AppState>
 
                                         <CodeMirror
                                             className="cue-editor cue-editor--terminal"
-                                            theme={ vscodeLight }
+                                            theme={ vscodeLightTerminal }
                                             placeholder="// ... loading WASM"
+                                            basicSetup={ false }
                                             editable={ false }
                                             extensions={ this.getExtensions( outputTab.selected.value) }
                                             onCreateEditor={ async(view) => {
@@ -439,11 +441,16 @@ export class App extends React.Component<AppProps, AppState>
     }
 
     private getExtensions(languageValue: string): Extension[] {
-        const extensions: Extension[] = [];
+        const extensions = basicSetup({
+            highlightActiveLine: false,
+            highlightActiveLineGutter: false,
+        });
+
         const language = loadLanguage(languageValue as LanguageName);
         if (language) {
             extensions.push(language);
         }
+
         return extensions;
     }
 }

--- a/playground/src/scss/components/editor.scss
+++ b/playground/src/scss/components/editor.scss
@@ -13,15 +13,5 @@
 
     &--terminal {
         background: $c-output-bcg;
-
-        .cm-editor,
-        .cm-gutters {
-            background: $c-output-bcg;
-        }
-
-        .cm-activeLine,
-        .cm-activeLineGutter {
-            background: $c-output-highlight;
-        }
     }
 }

--- a/playground/src/scss/config/colors.scss
+++ b/playground/src/scss/config/colors.scss
@@ -39,5 +39,4 @@ $c-error:               $c-red;
 $c-success:             #16b51e;
 $c-input:               $c-grey;
 $c-output-bcg:          $c-grey-blue--light;
-$c-output-highlight:    $c-grey-blue;
 $shadow-menu:           0 4px 10px 0 transparentize($c-black, 0.8);


### PR DESCRIPTION
- Overwrite part of the vscode theme so the line highlight is transparent so the word highlight is also visible
- Turn off highlight active line by overruling part of the basic setup optionsof the code-mirror editor
- Remove css overrides & use vscodeLight terminal theme which overrides part of the vscode light theme
- Change selectionMatch color so it matches the selection color (blue instead of brown)
- Uncomment updateOutput function (should be on)

Fixes: https://github.com/cue-lang/cue/issues/3239

To test:
Go to /play
- Select a part of the code: it should be blue now
- Double-click a word: it should be blue instead of brown
- Do the same for the output editor
- Click on a line: line should not be highlighted