### PR TITLE
playground: Fix editor growing outside of it's container

### DIFF
--- a/playground/src/scss/components/columns.scss
+++ b/playground/src/scss/components/columns.scss
@@ -13,6 +13,7 @@
 
     &__item {
         display: grid;
+        grid-template-columns: minmax(0, 1fr);
         grid-template-rows: repeat(auto-fit, minmax(100px, 1fr));
         min-height: 40vh;
 


### PR DESCRIPTION
- Set grid columns for the columns__item to minmax(0, 1fr) so column__subitem's don't grow out of their container anymore. The minimum with of grid-column is set to 'auto' by default, so it grows with its content. By setting it to minmax (0, 1fr) we set the minimum to 0 and make it grow to it's parent by using max 1fr. If an item is too wide a scrollbar appears instead of the item growing too big and not being visible because it's behind the 2nd editor.

Fixes: https://github.com/cue-lang/cue/issues/3266

To test:
Go to https://deploy-preview-464--cue.netlify.app/play/?id=sJAM4FCiz6n#w=function&i=cue&f=eval&o=cue
- The editor should be scrollable instead to see the whole link.