### PR TITLE
playground: Playground gets stuck at "... loading WASM"

### DIFF
--- a/playground/src/containers/app.tsx
+++ b/playground/src/containers/app.tsx
@@ -46,6 +46,7 @@ interface AppState
     saved: boolean;
     showSaveURL: boolean;
     activeExample?: Example;
+    outputEditorValue?: string;
 }
 
 // App is the root of our React application
@@ -64,6 +65,7 @@ export class App extends React.Component<AppProps, AppState>
             saved: false,
             showSaveURL: false,
             activeExample: null,
+            outputEditorValue: undefined,
         };
     }
 
@@ -295,15 +297,15 @@ export class App extends React.Component<AppProps, AppState>
                                         name={ outputTab.title }
                                         type="output"
                                     >
-
                                         <CodeMirror
                                             className="cue-editor cue-editor--terminal"
                                             theme={ vscodeLightTerminal }
                                             placeholder="// ... loading WASM"
+                                            value={ this.state.outputEditorValue }
                                             basicSetup={ false }
                                             editable={ false }
                                             extensions={ this.getExtensions( outputTab.selected.value) }
-                                            onCreateEditor={ async(view) => {
+                                            onCreateEditor={ (view) => {
                                                 this.outputEditor = view;
                                                 this.updateOutput();
                                             } }
@@ -376,13 +378,12 @@ export class App extends React.Component<AppProps, AppState>
     }
 
     private updateOutput(): void {
-        const activeWorkspace = this.state.workspaces[this.state.activeWorkspaceName];
-
-        if (this.props.WasmAPI.CUECompile === undefined ||
-            this.inputEditors === undefined || this.outputEditor === undefined) {
+        if (!this.props.WasmAPI.CUECompile ||
+            Object.keys(this.inputEditors).length === 0 || !this.outputEditor) {
             return;
         }
 
+        const activeWorkspace = this.state.workspaces[this.state.activeWorkspaceName];
         /* TODO: this part is just to make current function workspace output to keep working with the new setup
     but it will be replaced by a dynamic setup for all workspaces: see commented out code below */
         /* START OF (OLD) FUNCTION CODE */
@@ -398,12 +399,7 @@ export class App extends React.Component<AppProps, AppState>
         if (val === '') {
             val = result.value;
         }
-
-        const transaction = this.outputEditor.state.update({
-            changes: { from: 0, to: this.outputEditor.state.doc.length, insert: val },
-        });
-        this.outputEditor.dispatch(transaction);
-        this.outputEditor.dispatch({ selection: { anchor: 0 } });
+        this.setState({ outputEditorValue: val });
         /* END OF FUNCTION CODE */
 
 


### PR DESCRIPTION
- Fix check on inputEditors empty: it should check if not empty object instead
of undefined because default state is empty object.
- Change === undefined checks to use ! so it also covers null
- Move getting activeworkspace after the if statement because there is no need
to getting it when editors and wasm aren't ready
- Use react state to update value of output editor instead of transaction
because with transaction the change doesn't always update the state
correctly because it can conflict with other state changes of the editor.

Fixes: https://github.com/cue-lang/cue/issues/3271

To test:
Go to https://deploy-preview-465--cue.netlify.app/play/?id=6sgdmi8vArV#w=function&i=cue&f=eval&o=cueAfter loading the output editor should display the output code instead of
"loading wasm"