### PR TITLE
hugo: Toc: always show parent pages of active page in tree

### DIFF
--- a/hugo/layouts/partials/paging/tree.html
+++ b/hugo/layouts/partials/paging/tree.html
@@ -56,7 +56,8 @@
     {{ $pages := slice }}
     {{/* Only add pages that are active or have toc_hide set to false */}}
     {{ range (union $s.Pages $s.Sections).ByWeight -}}
-        {{ if or (eq . $p) (ne .Params.toc_hide true) -}}
+        {{ $pageIsActivePath := ($p.IsDescendant .) -}}
+        {{ if or (eq . $p) $pageIsActivePath (ne .Params.toc_hide true) -}}
             {{ $pages = $pages | append . }}
         {{- end }}
     {{- end }}


### PR DESCRIPTION
When getting the page of a section also show pages which are ancestors of the current page. (page is descendant of page in loop). So effectively  ignore toc_hide for those pages

Fixes: https://github.com/cue-lang/cue/issues/3277

To test:
- Set toc_hide: to true on content/docs/reference/command/_en.md
- Go to /docs/reference/command/cue-help/ > "The cue command" item + tree should show
- Go to another page in the tree, for example /docs/reference/glossary > "The cue command" item should not show