### PR TITLE
hugo: Filter on hidden facet inputs for search widget

### DIFF
--- a/hugo/assets/ts/helpers/search.ts
+++ b/hugo/assets/ts/helpers/search.ts
@@ -106,3 +106,23 @@ export const parseQuery = (query: string): ParsedQuery => {
         facets: cleanObject<SearchFacets>(facets),
     };
 };
+
+export const getHiddenInputFacets = (facetInputs: NodeListOf<HTMLInputElement>): SearchFacets => {
+    if (!facetInputs) {
+        return {};
+    }
+
+    const facets: SearchFacets = {
+        [SearchFacet.TAGS]: [],
+        [SearchFacet.CONTENT_TYPE]: [],
+    };
+
+    facetInputs.forEach((input) => {
+        const name = input.getAttribute('name').replace('facet-', '');
+        if (facets[name] && input.value && input.value !== '') {
+            facets[name].push(input.value);
+        }
+    });
+
+    return cleanObject<SearchFacets>(facets);
+};

--- a/hugo/assets/ts/widgets/search-results.ts
+++ b/hugo/assets/ts/widgets/search-results.ts
@@ -1,11 +1,10 @@
+import { Hit } from '@algolia/client-search';
 import algoliasearch, { SearchClient, SearchIndex } from 'algoliasearch';
 import merge from 'lodash.merge';
-import { Hit } from '@algolia/client-search';
-import { BaseWidget } from './base-widget';
+import { getHiddenInputFacets, mapToAlgoliaFilters, parseQuery } from '../helpers/search';
 import { FilterEvent, FilterItem, SearchEvents, SearchFacet, SearchFacets, SearchItem } from '../interfaces/search';
 import { Teaser } from '../interfaces/teaser';
-import { mapToAlgoliaFilters, parseQuery } from '../helpers/search';
-import { cleanObject } from 'assets/ts/helpers/cleaner';
+import { BaseWidget } from './base-widget';
 
 export class SearchResults extends BaseWidget {
     public static readonly NAME = 'search-results';
@@ -128,24 +127,12 @@ export class SearchResults extends BaseWidget {
         `;
     }
 
+
     private getHiddenInputFacets(): SearchFacets {
         if (!this.facetInputs) {
             return {};
         }
-
-        const facets: SearchFacets = {
-            [SearchFacet.TAGS]: [],
-            [SearchFacet.CONTENT_TYPE]: [],
-        };
-
-        this.facetInputs.forEach((input) => {
-            const name = input.getAttribute('name').replace('facet-', '');
-            if (facets[name] && input.value && input.value !== '') {
-                facets[name].push(input.value);
-            }
-        });
-
-        return cleanObject<SearchFacets>(facets);
+        return getHiddenInputFacets(this.facetInputs);
     }
 
     private handleTagClick(value: string) {


### PR DESCRIPTION
- Move function go get facets from hidden inputs to helper so it can be used for both results & autocomplete
- Change function arguments of suggestions & autocomplete config to arrow functions so 'this' can be used. Move inline functions to the class itself.
- For searchbar of type results also get facets from the hidden inputs and not just from the url.
- Get search url for suggestions from window location when is widget; otherwise use main search url

 Fixes https://github.com/cue-lang/cue/issues/2841

 To test:
 - Go to https://deploy-preview-467--cue.netlify.app/docs/concept/find-a-guide
 - Type a search term into the bar.
 - When you click one of the suggestions you stay on the same page and search for the suggestion instead of going to the main search page
 - The suggested page items are within the concept guide section
 - When entering a term and hitting enter or the search button you stay on the same page and search for the entered term