### PR TITLE
hugo: Fix linewrap codeblock

### DIFF
--- a/hugo/assets/scss/base/base.scss
+++ b/hugo/assets/scss/base/base.scss
@@ -340,6 +340,7 @@ code {
     font-style: normal;
     font-weight: inherit;
     line-height: inherit;
+    white-space: pre;
 
     ul &,
     ol &,


### PR DESCRIPTION
- Adds white-space: pre on base code block element for proper linewrapping on Chrome.

To test: go to https://cuelang.org/docs/howto/embed-files-in-cue-evaluation/ and find the line with `type=<filetype>` in the Chrome browser. This should not wrap over 2 lines anymore.

Fixes [#3287](https://github.com/developer-usmedia/cuelang.org/compare/feature/3287)