### PR TITLE
hugo: Fix scroll on code tabs element

### DIFF
--- a/hugo/assets/scss/components/tabs-nav.scss
+++ b/hugo/assets/scss/components/tabs-nav.scss
@@ -11,9 +11,11 @@
 
     &__tabs {
         display: flex;
+        overflow: auto hidden;
         padding: 0 $p-gutter;
         scroll-behavior: smooth;
-        scrollbar-width: none;
+        scrollbar-gutter: stable;
+        scrollbar-width: thin;
     }
 
     &__item {


### PR DESCRIPTION
This fixes an issue where the filenames in a code-tabs element can't be
scrolled horizontally if they are collectively wider than the element.
An example of this happening is on
https://cuelang.org/docs/concept/using-the-cue-export-command/inputs/#cue-package-file-inputs

Fixes cue-lang/cue#3502

--

To test, go to https://deploy-preview-473--cue.netlify.app/docs/concept/using-the-cue-export-command/inputs/#cue-package-file-inputs and see underneath the line "In all these situations the inputs are unified".