### PR TITLE
hugo: Fix header not being hidden when scrolling to anchor.

### DIFF
--- a/hugo/assets/ts/widgets/header.ts
+++ b/hugo/assets/ts/widgets/header.ts
@@ -45,7 +45,7 @@ export class Header extends BaseWidget {
 
     public onScroll(): void {
         this.scrollY = window.scrollY;
-        this.scrollingDown = (this.scrollY > this.scrollYOld);
+        this.scrollingDown = (this.scrollY >= this.scrollYOld);
         this.scrollYOld = this.scrollY;
 
         if (!this.updateScheduled) {

--- a/hugo/assets/ts/widgets/tabs-nav.ts
+++ b/hugo/assets/ts/widgets/tabs-nav.ts
@@ -38,6 +38,10 @@ export class TabsNav extends BaseWidget {
     }
 
     public init(): void {
+        if (!this.tabList) {
+            return;
+        }
+
         this.checkPaginationEnabled();
 
         // Reset scroll + check for pagination on resize
@@ -63,6 +67,7 @@ export class TabsNav extends BaseWidget {
             this.handlePagination('next');
         });
     }
+
     public checkPaginationEnabled(): void {
         // Calculate if tablist doesn't fit in container
         const elemWidth = this.element.offsetWidth +


### PR DESCRIPTION
- Fix js error on the tabs-nav widget which caused the javascript to fail when only 1 tab was present (console error about undefined tabslist)
- Fix check on scrolldown: when scroll Y old is equal to scroll y new it should not assume it's scrolling up again.
 If a scroll-to-anchor was triggered twice (what happened here for some
 reason) it wrongly set scrolLDown to false while the old-Y & new-Y position
 were the same.

To test:
Go to /docs/concept/modules-packages-instances/#instances You should scroll down to the anchor and the header should be hidden.

Closes https://github.com/cue-lang/cue/issues/3058