### PR TITLE
hugo: Fix auto-font-size on iphone - safari

### DIFF
--- a/hugo/assets/scss/base/base.scss
+++ b/hugo/assets/scss/base/base.scss
@@ -52,6 +52,7 @@ body {
 
     background-color: var(--body-background, $c-white);
     color: var(--text-color);
+    -webkit-text-size-adjust: 100%;
 }
 
 h1,


### PR DESCRIPTION
- Turn off webkit text-size-adjust so Safari in Iphone to make sure Safari doesn't zoom in the text anymore

To test:
Go to https://cuelang.org/docs/concept/how-cue-works-with-json/#validating-json-files-against-a-schema on Safari on an Iphone. The text inside the code block should no be zoomed in anymore

Fixes: cue-lang/cue#3602