### PR TITLE
playground: Fix loading of an example while id is in the url.

### DIFF
--- a/playground/src/components/examples-menu.tsx
+++ b/playground/src/components/examples-menu.tsx
@@ -4,7 +4,7 @@ import Fuse from 'fuse.js';
 import { Example, ExamplesByCategory } from '@models/example';
 import { examples } from '@config/examples';
 import { categoryWeight } from '@config/examples/categories';
-import { getSearchParamsFromUrl, updateSearchParams } from '@helpers/url-params';
+import { updateSearchParams } from '@helpers/url-params';
 import cx from 'classnames';
 
 interface ExampleMenuProps {
@@ -81,9 +81,9 @@ export class ExamplesMenu extends React.Component<ExampleMenuProps, ExampleMenuS
     }
 
     public updateUrl(example: Example) {
-        const params = getSearchParamsFromUrl();
+        const params = new URLSearchParams();
         params.set('example', example.slug);
-        updateSearchParams(params);
+        updateSearchParams(params, true);
         this.props.onClose();
     }
 

--- a/playground/src/containers/app.tsx
+++ b/playground/src/containers/app.tsx
@@ -25,7 +25,13 @@ import { vscodeLight, vscodeLightTerminal } from '@config/editor-theme';
 import { examples } from '@config/examples';
 import { availableWorkspaces, defaultWorkspace } from '@config/workspaces';
 import { getSharedCode, share, workspaceToShareContent } from '@helpers/share';
-import { getHashParamsFromUrl, getSearchParamsFromUrl, updateHash, workspaceToHashParams } from '@helpers/url-params';
+import {
+    getHashParamsFromUrl,
+    getSearchParamsFromUrl,
+    updateHash,
+    updateSearchParams,
+    workspaceToHashParams
+} from '@helpers/url-params';
 import { setupWorkspaceConfig } from '@helpers/workspace';
 import { DropdownChange } from '@models/dropdown';
 import { Example } from '@models/example';
@@ -98,6 +104,12 @@ export class App extends React.Component<AppProps, AppState>
             if (sharedCode) {
                 saved = true;
                 activeWorkspace = availableWorkspaces[sharedCode.workspace] ?? defaultWorkspace;
+
+                if (urlSearchParams.get('example')) {
+                    urlSearchParams.delete('example');
+                    updateSearchParams(urlSearchParams, true);
+                }
+
                 for (const savedInput of sharedCode.inputs) {
                     const inputTab = activeWorkspace.config.inputTabs.find(tab => tab.type = savedInput.type);
                     if (inputTab) {


### PR DESCRIPTION
- Loading an example should replace the url: not add a parameter to it.
- If both id & example are in the url params: remove the example parameter from the url

To test:
Go to /play?id=eVdbhSP1QnG&example=test-example#w=function&i=cue&f=eval&o=cue > the example parameter should be removed Click on an example: the example should load and replace the saved code

Fixes: cue-lang/cue#2994