### PR TITLE
hugo: do not show anchor link in shortcode header

### DIFF
--- a/hugo/assets/scss/components/anchor.scss
+++ b/hugo/assets/scss/components/anchor.scss
@@ -4,6 +4,7 @@
 .anchor {
     $self: &;
 
+    cursor: default;
     left: -$p-gutter;
     padding-right: 2rem; // make sure there is overlap between anchor and heading
     position: absolute;

--- a/hugo/assets/scss/components/article.scss
+++ b/hugo/assets/scss/components/article.scss
@@ -58,6 +58,27 @@
         margin-right: auto;
     }
 
+    &__content {
+        > h1,
+        > h2,
+        > h3,
+        > h4,
+        > h5,
+        > h6 {
+            position: relative;
+
+            &:hover {
+                .anchor {
+                    cursor: pointer;
+                }
+
+                .anchor__icon {
+                    visibility: visible;
+                }
+            }
+        }
+    }
+
     &__content,
     &__footer {
         @include container($w-content--small);
@@ -127,24 +148,11 @@
             @include container($w-content);
         }
 
-        h4,
-        h5,
-        h6 {
-            font-size: 1rem;
-        }
-    }
-
-    h1,
-    h2,
-    h3,
-    h4,
-    h5,
-    h6 {
-        position: relative;
-
-        &:hover {
-            .anchor__icon {
-                visibility: visible;
+        #{ $self }__content {
+            h4,
+            h5,
+            h6 {
+                font-size: 1rem;
             }
         }
     }


### PR DESCRIPTION
* Moved css to only show the anchor hover state on direct descendents of article__content, so the
anchor does not show inside a shortcode
* Set behaviour of cursor so it does not show the pointer when we do not show the anchor

To test:
* Go to /examples/shortcodes/info and check if the anchor icon does not show on hover on the
shortcode titles
* Also check other shortcodes for the same behaviour

Fixes: https://github.com/cue-lang/cue/issues/3279