### PR TITLE
hugo: show background color on all inline code blocks

### DIFF
--- a/hugo/assets/scss/base/base.scss
+++ b/hugo/assets/scss/base/base.scss
@@ -336,22 +336,16 @@ pre {
 }
 
 code {
+    --pre-background-color: #{ $c-grey-blue };
+
+    background-color: var(--pre-background-color);
+    border-radius: 2px;
     font-size: inherit;
     font-style: normal;
     font-weight: inherit;
     line-height: inherit;
+    padding: 0 4px;
     white-space: pre;
-
-    ul &,
-    ol &,
-    dl &,
-    p & {
-        --pre-background-color: #{ $c-grey-blue };
-
-        background-color: var(--pre-background-color);
-        border-radius: 2px;
-        padding: 0 4px;
-    }
 }
 
 pre {
@@ -364,6 +358,10 @@ pre {
     max-width: 100%;
     overflow-x: auto;
     padding: 0.875rem 1rem;
+
+    code {
+        --pre-background-color: transparent;
+    }
 }
 
 audio,


### PR DESCRIPTION
* Removed the code that only adds a background to inline code when inside p or list
* Give code element a transparent background when inside of pre element.

Test:
* Add inline code to some steps and see if they have a background color:
/examples/shortcodes/step/
* Check all other uses for code, not only inline, e.g.:
    * /examples/basic/code-block/
    * /examples/shortcodes/code-tabs/

Fixes
https://github.com/cue-lang/cue/issues/3003
and
https://github.com/cue-lang/cue/issues/3498