### PR TITLE
hugo: add searchTerm option to search shortcode

### DIFF
--- a/content/examples/shortcodes/search/en.md
+++ b/content/examples/shortcodes/search/en.md
@@ -8,10 +8,10 @@ With this shortcode you can embed a search results widget on the page.
 ## Example
 
 ```
-{{</* search contentType="How-to Guides" showContentTypes=false tags="encodings,commented cue" */>}}
+{{</* search contentType="Tutorials" showContentTypes=false tags="encodings,cue command" searchTerm="\"json schema\"" */>}}
 ```
 
-{{< search contentType="How-to Guides" showContentTypes=false tags="encodings,commented cue" >}}
+{{< search contentType="Tutorials" showContentTypes=false tags="encodings,cue command" searchTerm="\"json schema\"" >}}
 
 
 ## Attributes
@@ -24,3 +24,6 @@ showContentTypes
 
 tags
 : optional - Adds preselected tags
+
+searchTerm
+: optional - Prefills the search bar

--- a/hugo/assets/ts/helpers/search.ts
+++ b/hugo/assets/ts/helpers/search.ts
@@ -63,6 +63,15 @@ export const queryToUrlParams = (query: ParsedQuery): string => {
     return queryString;
 };
 
+export const updateSearchParams = (parsedQuery: ParsedQuery, refresh = true): void => {
+    const url = `${ window.location.href.split('?')[0] }?${ queryToUrlParams(parsedQuery) }`;
+    if (!refresh) {
+        window.history.pushState(null, '', url);
+    } else {
+        window.location.href = url;
+    }
+};
+
 // eslint-disable-next-line max-lines-per-function
 export const parseQuery = (query: string): ParsedQuery => {
     if (!query) {

--- a/hugo/assets/ts/widgets/search-filter.ts
+++ b/hugo/assets/ts/widgets/search-filter.ts
@@ -1,6 +1,6 @@
 // eslint-disable-next-line
 import Fuse from 'fuse.js';
-import { parseQuery, queryToUrlParams } from '../helpers/search';
+import { parseQuery, updateSearchParams } from '../helpers/search';
 import { FilterEvent, FilterItem, ParsedQuery, SearchEvents } from '../interfaces/search';
 import { BaseWidget } from './base-widget';
 
@@ -141,12 +141,7 @@ export class SearchFilter extends BaseWidget {
     }
 
     private updateUrl(refresh = true) {
-        const url = `${ window.location.href.split('?')[0] }?${ queryToUrlParams(this.parsedQuery) }`;
-        if (!refresh) {
-            window.history.pushState(null, '', url);
-        } else {
-            window.location.href = url;
-        }
+        updateSearchParams(this.parsedQuery, refresh);
     }
 
     private getParams(): void {

--- a/hugo/content/en/examples/shortcodes/search/index.md
+++ b/hugo/content/en/examples/shortcodes/search/index.md
@@ -8,10 +8,10 @@ With this shortcode you can embed a search results widget on the page.
 ## Example
 
 ```
-{{</* search contentType="How-to Guides" showContentTypes=false tags="encodings,commented cue" */>}}
+{{</* search contentType="Tutorials" showContentTypes=false tags="encodings,cue command" searchTerm="\"json schema\"" */>}}
 ```
 
-{{< search contentType="How-to Guides" showContentTypes=false tags="encodings,commented cue" >}}
+{{< search contentType="Tutorials" showContentTypes=false tags="encodings,cue command" searchTerm="\"json schema\"" >}}
 
 
 ## Attributes
@@ -24,3 +24,6 @@ showContentTypes
 
 tags
 : optional - Adds preselected tags
+
+searchTerm
+: optional - Prefills the search bar

--- a/hugo/layouts/partials/search.html
+++ b/hugo/layouts/partials/search.html
@@ -3,6 +3,7 @@
 {{ $contentTypes := slice }}
 {{ $contentType := .contentType | default "" }}
 {{ $preselectedTags := .preselectedTags | default "" }}
+{{ $searchTerm := .searchTerm | default "" }}
 {{ $type := .type | default "full" }}
 {{ $placeholder := (T "search_placeholder" ) }}
 
@@ -32,6 +33,7 @@
                 "type" "results"
                 "inputId" "searchbar"
                 "placeholder" $placeholder
+                "searchTerm" $searchTerm
             ) -}}
         </div>
         <div class="search__options">

--- a/hugo/layouts/partials/searchbar.html
+++ b/hugo/layouts/partials/searchbar.html
@@ -3,10 +3,12 @@
 {{ $modifier := .modifier | default "" }}
 {{ $type := .type | default "" }}
 {{ $placeholder := .placeholder | default "" }}
+{{ $searchTerm := .searchTerm | default "" }}
 
 <div data-search-autocomplete="{{ $type }}"
      data-searchbar-size="{{ if not (eq $type "results") }}small{{ end }}"
      data-searchbar-placeholder="{{ $placeholder }}"
+     data-searchbar-search-term="{{ $searchTerm }}"
 >
     <div id="autocomplete-{{ $type }}"></div>
 </div>

--- a/hugo/layouts/shortcodes/search.html
+++ b/hugo/layouts/shortcodes/search.html
@@ -1,11 +1,13 @@
 {{- $contentType := .Get "contentType" | default "" -}}
 {{- $showContentTypes := .Get "showContentTypes" | default true -}}
 {{- $preselectedTags := .Get "tags" | default "" -}}
+{{- $searchTerm := .Get "searchTerm" | default "" -}}
 
 {{- partial "search"  (dict
     "type" "widget"
     "contentType" $contentType
     "showContentTypes" $showContentTypes
     "preselectedTags" $preselectedTags
+    "searchTerm" $searchTerm
     "context" .
 ) -}}


### PR DESCRIPTION
* Add searchTerm to example page
* Pass searchTerm from search shortcode, through search partial, to searchbar partial
* Set initial state with searchItem

To test:
* Navigate to /examples/shortcodes/search and verify that the search results are accurate.

Fixes https://github.com/cue-lang/cue/issues/3566