### PR TITLE
hugo: fix padding for code blocks based on their use

### DIFF
--- a/hugo/assets/scss/base/base.scss
+++ b/hugo/assets/scss/base/base.scss
@@ -338,6 +338,7 @@ pre {
 
 code {
     --pre-background-color: #{ $c-grey-blue };
+    --pre-padding: 0 4px;
 
     background-color: var(--pre-background-color);
     border-radius: 2px;
@@ -345,7 +346,7 @@ code {
     font-style: normal;
     font-weight: inherit;
     line-height: inherit;
-    padding: 0 4px;
+    padding: var(--pre-padding);
     white-space: pre;
 }
 
@@ -362,6 +363,7 @@ pre {
 
     code {
         --pre-background-color: transparent;
+        --pre-padding: 0;
     }
 }
 


### PR DESCRIPTION
* Give code element no padding when inside of pre element.

Test:
* Check padding on code and inline code blocks
  * docs/howto/specify-a-default-value-for-a-field/

Fixes cue-lang/cue#3656